### PR TITLE
Move connection info from heat.conf to template

### DIFF
--- a/doc/templates/member.yaml
+++ b/doc/templates/member.yaml
@@ -8,6 +8,7 @@ resources:
   grid_member:
     type: Infoblox::Grid::Member
     properties:
+      connection: { url: "https://172.22.128.92/wapi/v2.3", username: admin, password: infoblox, sslverify: False }
       name: nios-test.infoblox.local
       model: IB-VM-820
       LAN1: 121749db-d096-49f5-a483-1209b55890ef

--- a/heat_infoblox/constants.py
+++ b/heat_infoblox/constants.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2016 Infoblox Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+# Common constants
+
+CONNECTION = 'connection'
+URL = 'url'
+USERNAME = 'username'
+PASSWORD = 'password'
+SSLVERIFY = 'sslverify'
+
+NETMRI = 'NetMRI'
+DDI = 'Infoblox'

--- a/heat_infoblox/resources/grid_member.py
+++ b/heat_infoblox/resources/grid_member.py
@@ -23,6 +23,7 @@ from heat.engine import properties
 from heat.engine import resource
 from heat.engine import support
 
+from heat_infoblox import constants
 from heat_infoblox import resource_utils
 
 
@@ -116,17 +117,17 @@ class GridMember(resource.Resource):
         _('See support.infoblox.com for support.'))
 
     properties_schema = {
+        constants.CONNECTION:
+            resource_utils.connection_schema(constants.DDI),
         NAME: properties.Schema(
             properties.Schema.STRING,
-            _('Member name.'),
-        ),
+            _('Member name.')),
         MODEL: properties.Schema(
             properties.Schema.STRING,
             _('Infoblox model name.'),
             constraints=[
                 constraints.AllowedValues(ALLOWED_MODELS)
-            ]
-        ),
+            ]),
         LICENSES: properties.Schema(
             properties.Schema.LIST,
             _('List of licenses to pre-provision.'),
@@ -135,8 +136,7 @@ class GridMember(resource.Resource):
             ),
             constraints=[
                 constraints.AllowedValues(ALLOWED_LICENSES_PRE_PROVISION)
-            ]
-        ),
+            ]),
         TEMP_LICENSES: properties.Schema(
             properties.Schema.LIST,
             _('List of temporary licenses to apply to the member.'),
@@ -145,32 +145,26 @@ class GridMember(resource.Resource):
             ),
             constraints=[
                 constraints.AllowedValues(ALLOWED_LICENSES_TEMP)
-            ]
-        ),
+            ]),
         REMOTE_CONSOLE: properties.Schema(
             properties.Schema.BOOLEAN,
-            _('Enable the remote console.')
-        ),
+            _('Enable the remote console.')),
         ADMIN_PASSWORD: properties.Schema(
             properties.Schema.STRING,
-            _('The password to use for the admin user.')
-        ),
+            _('The password to use for the admin user.')),
         GM_IP: properties.Schema(
             properties.Schema.STRING,
             _('The Gridmaster IP address.'),
-            required=True
-        ),
+            required=True),
         GM_CERTIFICATE: properties.Schema(
             properties.Schema.STRING,
             _('The Gridmaster SSL certificate for verification.'),
-            required=False
-        ),
+            required=False),
         NAT_IP: properties.Schema(
             properties.Schema.STRING,
             _('If the GM will see this member as a NATed address, enter that '
               'address here.'),
-            required=False
-        ),
+            required=False),
         MGMT_PORT: resource_utils.port_schema(MGMT_PORT, False),
         LAN1_PORT: resource_utils.port_schema(LAN1_PORT, True),
         LAN2_PORT: resource_utils.port_schema(LAN2_PORT, False),
@@ -184,8 +178,7 @@ class GridMember(resource.Resource):
                     _('If true, enable DNS on this member.'),
                     default=False
                 ),
-            }
-        )
+            })
     }
 
     attributes_schema = {
@@ -219,7 +212,8 @@ class GridMember(resource.Resource):
 
     def infoblox(self):
         if not getattr(self, 'infoblox_object', None):
-            self.infoblox_object = resource_utils.connect_to_infoblox()
+            conn = self.properties[constants.CONNECTION]
+            self.infoblox_object = resource_utils.connect_to_infoblox(conn)
         return self.infoblox_object
 
     def _make_port_network_settings(self, port_name):

--- a/heat_infoblox/resources/nameserver_group_member.py
+++ b/heat_infoblox/resources/nameserver_group_member.py
@@ -22,6 +22,7 @@ from heat.engine import properties
 from heat.engine import resource
 from heat.engine import support
 
+from heat_infoblox import constants
 from heat_infoblox import resource_utils
 
 
@@ -60,17 +61,17 @@ class NameServerGroupMember(resource.Resource):
         _('See support.infoblox.com for support.'))
 
     properties_schema = {
+        constants.CONNECTION:
+            resource_utils.connection_schema(constants.DDI),
         GROUP_NAME: properties.Schema(
             properties.Schema.STRING,
-            _('Name server group name.'),
-        ),
+            _('Name server group name.')),
         MEMBER_ROLE: properties.Schema(
             properties.Schema.STRING,
             _('The role the member plays in the group.'),
             constraints=[
                 constraints.AllowedValues(MEMBER_ROLES)
-            ]
-        ),
+            ]),
         MEMBER_SERVER: properties.Schema(
             properties.Schema.MAP,
             _('A grid member settings in this group.'),
@@ -92,8 +93,7 @@ class NameServerGroupMember(resource.Resource):
                       'secondary for the group.'),
                     default=False
                 ),
-            }
-        ),
+            }),
     }
 
     attributes_schema = {
@@ -104,7 +104,8 @@ class NameServerGroupMember(resource.Resource):
 
     def infoblox(self):
         if not getattr(self, 'infoblox_object', None):
-            self.infoblox_object = resource_utils.connect_to_infoblox()
+            conn = self.properties[constants.CONNECTION]
+            self.infoblox_object = resource_utils.connect_to_infoblox(conn)
         return self.infoblox_object
 
     def _remove_member(self, member_list, member):

--- a/heat_infoblox/resources/netmri_job.py
+++ b/heat_infoblox/resources/netmri_job.py
@@ -22,6 +22,9 @@ from heat.engine import properties
 from heat.engine import resource
 from heat.engine import support
 
+from heat_infoblox import constants
+from heat_infoblox import resource_utils
+
 import infoblox_netmri as netmri
 
 LOG = logging.getLogger(__name__)
@@ -31,13 +34,11 @@ class NetMRIJob(resource.Resource):
     '''A resource which represents a job executed in NetMRI.'''
 
     PROPERTIES = (
-        CONNECTION, URL, USERNAME, PASSWORD, SSLVERIFY,
         SOURCE, SCRIPT, JOB_SPEC, TEMPLATE,
         WAIT, INPUTS, TARGETS,
         DEVICE_ID, DEVICE_IP_ADDR, DEVICE_NET_IP_ADDR,
         NETWORK_VIEW
     ) = (
-        'connection', 'url', 'username', 'password', 'sslverify',
         'source', 'script', 'job_specification', 'config_template',
         'wait', 'inputs', 'targets',
         'device_id', 'device_ip_address', 'device_netview_ip_addr',
@@ -55,33 +56,8 @@ class NetMRIJob(resource.Resource):
     support_status = support.SupportStatus(support.UNSUPPORTED)
 
     properties_schema = {
-        CONNECTION: properties.Schema(
-            properties.Schema.MAP,
-            required=True,
-            schema={
-                URL: properties.Schema(
-                    properties.Schema.STRING,
-                    _('The URL to the NetMRI API (example: '
-                      'https://netmri/api/3.0)'),
-                    required=True
-                ),
-                USERNAME: properties.Schema(
-                    properties.Schema.STRING,
-                    _('The username for NetMRI.'),
-                    required=True
-                ),
-                PASSWORD: properties.Schema(
-                    properties.Schema.STRING,
-                    _('The password for NetMRI.'),
-                    required=True
-                ),
-                SSLVERIFY: properties.Schema(
-                    properties.Schema.BOOLEAN,
-                    _('If True, the SSL certificate will be validated.'),
-                    default=True
-                ),
-            }
-        ),
+        constants.CONNECTION:
+            resource_utils.connection_schema(constants.NETMRI),
         SOURCE: properties.Schema(
             properties.Schema.MAP,
             required=True,
@@ -98,17 +74,14 @@ class NetMRIJob(resource.Resource):
                     properties.Schema.STRING,
                     _('The name or ID of the config template to run.')
                 ),
-            }
-        ),
+            }),
         WAIT: properties.Schema(
             properties.Schema.BOOLEAN,
             _('If true, the create will wait until the job completes.'),
-            default=True
-        ),
+            default=True),
         INPUTS: properties.Schema(
             properties.Schema.MAP,
-            _('The key/value pair inputs for the job.')
-        ),
+            _('The key/value pair inputs for the job.')),
         TARGETS: properties.Schema(
             properties.Schema.LIST,
             _('A list of targets (devices) against which to execute '
@@ -133,9 +106,7 @@ class NetMRIJob(resource.Resource):
                           'if specifying an IP and there are multiple network '
                           'views in the NetMRI.')
                     ),
-                },
-            ),
-        ),
+                })),
     }
 
     attributes_schema = {
@@ -153,7 +124,7 @@ class NetMRIJob(resource.Resource):
     def netmri(self):
         if not getattr(self, 'netmri_object', None):
             self.netmri_object = netmri.InfobloxNetMRI(
-                self.properties[self.CONNECTION]
+                self.properties[constants.CONNECTION]
             )
         return self.netmri_object
 

--- a/heat_infoblox/tests/test_resource_utils.py
+++ b/heat_infoblox/tests/test_resource_utils.py
@@ -28,16 +28,11 @@ class ResourceUtilsTest(common.HeatTestCase):
 
     def test_wapi_config_file(self):
 
-        for opt in ['wapi_url', 'username', 'password']:
-            cfg.CONF.set_override(name=opt,
-                                  override='test_%s' % opt,
-                                  group='infoblox')
-
-        cfg.CONF.set_override(name='sslverify',
-                              override=False,
-                              group='infoblox')
         connector.Infoblox = mock.MagicMock()
-        resource_utils.connect_to_infoblox()
+        resource_utils.connect_to_infoblox({'url': 'test_wapi_url',
+                                            'username': 'test_username',
+                                            'password': 'test_password',
+                                            'sslverify': False})
         connector.Infoblox.assert_called_with({'url': 'test_wapi_url',
                                                'username': 'test_username',
                                                'password': 'test_password',

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@
 
 pbr<2.0,>=1.4
 Babel>=1.3
--e git+https://git.openstack.org/openstack/heat.git@master#egg=heat
 oslo.config>=2.6.0 # Apache-2.0
 infoblox-netmri>=0.1.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,15 +7,13 @@ hacking<0.11,>=0.10.0
 bandit>=0.10.1
 coverage>=3.6
 discover
+-e git+https://git.openstack.org/openstack/heat.git@stable/liberty#egg=heat
 mock>=1.2
 mox>=0.5.3
 mox3>=0.7.0
-PyMySQL>=0.6.2 # MIT License
 oslosphinx>=2.5.0 # Apache-2.0
 oslotest>=1.10.0 # Apache-2.0
 paramiko>=1.13.0
-qpid-python;python_version=='2.7'
-psycopg2
 sphinx!=1.2.0,!=1.3b1,<1.3,>=1.1.2
 testrepository>=0.0.18
 testscenarios>=0.4


### PR DESCRIPTION
Change the WAPI connection info to be kept in the template file,
like is done with netmri_job.py. Created a common class to manage
both API connections.
