### PR TITLE
Enable use of multi-line certificate strings

### DIFF
--- a/heat_infoblox/resources/grid_member.py
+++ b/heat_infoblox/resources/grid_member.py
@@ -321,9 +321,9 @@ class GridMember(resource.Resource):
             user_data += 'gridmaster:\n'
             user_data += '  token: %s\n' % token[0]['token']
             user_data += '  ip_addr: %s\n' % self.properties[self.GM_IP]
-            user_data += '  certificate: %s\n' % self.properties[
+            user_data += '  certificate: |\n    %s\n' % self.properties[
                 self.GM_CERTIFICATE
-            ]
+            ].replace('\n', '\n    ')
 
         LOG.debug('user_data: %s' % user_data)
 

--- a/heat_infoblox/tests/test_grid_member.py
+++ b/heat_infoblox/tests/test_grid_member.py
@@ -177,7 +177,7 @@ class GridMemberTest(common.HeatTestCase):
             'gridmaster:\n'
             '  token: abcdefg\n'
             '  ip_addr: 10.1.1.2\n'
-            '  certificate: testing\n',
+            '  certificate: |\n    testing\n',
             ud
         )
 
@@ -193,7 +193,7 @@ class GridMemberTest(common.HeatTestCase):
             'gridmaster:\n'
             '  token: abcdefg\n'
             '  ip_addr: 10.1.1.2\n'
-            '  certificate: testing\n',
+            '  certificate: |\n    testing\n',
             ud
         )
 
@@ -212,7 +212,7 @@ class GridMemberTest(common.HeatTestCase):
             'gridmaster:\n'
             '  token: abcdefg\n'
             '  ip_addr: 10.1.1.2\n'
-            '  certificate: testing\n',
+            '  certificate: |\n    testing\n',
             ud
         )
 


### PR DESCRIPTION
The user_data being produced by the grid member resource expected
the certificate to be a single line. This change allows either
a single-line or multi-line certificate to be used.
