### PR TITLE
Move connection info from heat.conf to template

### DIFF
--- a/doc/templates/member.yaml
+++ b/doc/templates/member.yaml
@@ -8,6 +8,7 @@ resources:
   grid_member:
     type: Infoblox::Grid::Member
     properties:
+      connection: { url: "https://172.22.128.92/wapi/v2.3", username: admin, password: infoblox, sslverify: False }
       name: nios-test.infoblox.local
       model: IB-VM-820
       LAN1: 121749db-d096-49f5-a483-1209b55890ef

--- a/heat_infoblox/constants.py
+++ b/heat_infoblox/constants.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2016 Infoblox Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+# Common constants
+
+CONNECTION = 'connection'
+URL = 'url'
+USERNAME = 'username'
+PASSWORD = 'password'
+SSLVERIFY = 'sslverify'
+
+NETMRI = 'NetMRI'
+DDI = 'Infoblox'

--- a/heat_infoblox/resources/grid_member.py
+++ b/heat_infoblox/resources/grid_member.py
@@ -23,6 +23,7 @@ from heat.engine import properties
 from heat.engine import resource
 from heat.engine import support
 
+from heat_infoblox import constants
 from heat_infoblox import resource_utils
 
 
@@ -116,17 +117,17 @@ class GridMember(resource.Resource):
         _('See support.infoblox.com for support.'))
 
     properties_schema = {
+        constants.CONNECTION:
+            resource_utils.connection_schema(constants.DDI),
         NAME: properties.Schema(
             properties.Schema.STRING,
-            _('Member name.'),
-        ),
+            _('Member name.')),
         MODEL: properties.Schema(
             properties.Schema.STRING,
             _('Infoblox model name.'),
             constraints=[
                 constraints.AllowedValues(ALLOWED_MODELS)
-            ]
-        ),
+            ]),
         LICENSES: properties.Schema(
             properties.Schema.LIST,
             _('List of licenses to pre-provision.'),
@@ -135,8 +136,7 @@ class GridMember(resource.Resource):
             ),
             constraints=[
                 constraints.AllowedValues(ALLOWED_LICENSES_PRE_PROVISION)
-            ]
-        ),
+            ]),
         TEMP_LICENSES: properties.Schema(
             properties.Schema.LIST,
             _('List of temporary licenses to apply to the member.'),
@@ -145,32 +145,26 @@ class GridMember(resource.Resource):
             ),
             constraints=[
                 constraints.AllowedValues(ALLOWED_LICENSES_TEMP)
-            ]
-        ),
+            ]),
         REMOTE_CONSOLE: properties.Schema(
             properties.Schema.BOOLEAN,
-            _('Enable the remote console.')
-        ),
+            _('Enable the remote console.')),
         ADMIN_PASSWORD: properties.Schema(
             properties.Schema.STRING,
-            _('The password to use for the admin user.')
-        ),
+            _('The password to use for the admin user.')),
         GM_IP: properties.Schema(
             properties.Schema.STRING,
             _('The Gridmaster IP address.'),
-            required=True
-        ),
+            required=True),
         GM_CERTIFICATE: properties.Schema(
             properties.Schema.STRING,
             _('The Gridmaster SSL certificate for verification.'),
-            required=False
-        ),
+            required=False),
         NAT_IP: properties.Schema(
             properties.Schema.STRING,
             _('If the GM will see this member as a NATed address, enter that '
               'address here.'),
-            required=False
-        ),
+            required=False),
         MGMT_PORT: resource_utils.port_schema(MGMT_PORT, False),
         LAN1_PORT: resource_utils.port_schema(LAN1_PORT, True),
         LAN2_PORT: resource_utils.port_schema(LAN2_PORT, False),
@@ -184,8 +178,7 @@ class GridMember(resource.Resource):
                     _('If true, enable DNS on this member.'),
                     default=False
                 ),
-            }
-        )
+            })
     }
 
     attributes_schema = {
@@ -217,7 +210,8 @@ class GridMember(resource.Resource):
 
     def infoblox(self):
         if not getattr(self, 'infoblox_object', None):
-            self.infoblox_object = resource_utils.connect_to_infoblox()
+            conn = self.properties[constants.CONNECTION]
+            self.infoblox_object = resource_utils.connect_to_infoblox(conn)
         return self.infoblox_object
 
     def _make_port_network_settings(self, port_name):

--- a/heat_infoblox/resources/nameserver_group_member.py
+++ b/heat_infoblox/resources/nameserver_group_member.py
@@ -23,6 +23,7 @@ from heat.engine import properties
 from heat.engine import resource
 from heat.engine import support
 
+from heat_infoblox import constants
 from heat_infoblox import resource_utils
 
 
@@ -61,17 +62,17 @@ class NameServerGroupMember(resource.Resource):
         _('See support.infoblox.com for support.'))
 
     properties_schema = {
+        constants.CONNECTION:
+            resource_utils.connection_schema(constants.DDI),
         GROUP_NAME: properties.Schema(
             properties.Schema.STRING,
-            _('Name server group name.'),
-        ),
+            _('Name server group name.')),
         MEMBER_ROLE: properties.Schema(
             properties.Schema.STRING,
             _('The role the member plays in the group.'),
             constraints=[
                 constraints.AllowedValues(MEMBER_ROLES)
-            ]
-        ),
+            ]),
         MEMBER_SERVER: properties.Schema(
             properties.Schema.MAP,
             _('A grid member settings in this group.'),
@@ -93,8 +94,7 @@ class NameServerGroupMember(resource.Resource):
                       'secondary for the group.'),
                     default=False
                 ),
-            }
-        ),
+            }),
     }
 
     attributes_schema = {
@@ -104,7 +104,8 @@ class NameServerGroupMember(resource.Resource):
 
     def infoblox(self):
         if not getattr(self, 'infoblox_object', None):
-            self.infoblox_object = resource_utils.connect_to_infoblox()
+            conn = self.properties[constants.CONNECTION]
+            self.infoblox_object = resource_utils.connect_to_infoblox(conn)
         return self.infoblox_object
 
     def _remove_member(self, member_list, member):

--- a/heat_infoblox/resources/netmri_job.py
+++ b/heat_infoblox/resources/netmri_job.py
@@ -1,0 +1,272 @@
+# Copyright (c) 2015 Infoblox Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import logging
+
+from heat.common.i18n import _
+from heat.engine import attributes
+from heat.engine import constraints
+from heat.engine import properties
+from heat.engine import resource
+from heat.engine import support
+
+from heat_infoblox import constants
+from heat_infoblox import resource_utils
+
+import infoblox_netmri as netmri
+
+LOG = logging.getLogger(__name__)
+
+
+class NetMRIJob(resource.Resource):
+    '''A resource which represents a job executed in NetMRI.'''
+
+    PROPERTIES = (
+        SOURCE, SCRIPT, JOB_SPEC, TEMPLATE,
+        WAIT, INPUTS, TARGETS,
+        DEVICE_ID, DEVICE_IP_ADDR, DEVICE_NET_IP_ADDR,
+        NETWORK_VIEW
+    ) = (
+        'source', 'script', 'job_specification', 'config_template',
+        'wait', 'inputs', 'targets',
+        'device_id', 'device_ip_address', 'device_netview_ip_addr',
+        'network_view'
+    )
+
+    ATTRIBUTES = (
+        JOB,
+        JOB_DETAILS
+    ) = (
+        'job',
+        'job_details'
+    )
+
+    support_status = support.SupportStatus(support.UNSUPPORTED)
+
+    properties_schema = {
+        constants.CONNECTION:
+            resource_utils.connection_schema(constants.NETMRI),
+        SOURCE: properties.Schema(
+            properties.Schema.MAP,
+            required=True,
+            schema={
+                SCRIPT: properties.Schema(
+                    properties.Schema.STRING,
+                    _('The name or ID of the script to run.')
+                ),
+                JOB_SPEC: properties.Schema(
+                    properties.Schema.STRING,
+                    _('The name or ID of the job specification to run.')
+                ),
+                TEMPLATE: properties.Schema(
+                    properties.Schema.STRING,
+                    _('The name or ID of the config template to run.')
+                ),
+            }),
+        WAIT: properties.Schema(
+            properties.Schema.BOOLEAN,
+            _('If true, the create will wait until the job completes.'),
+            default=True),
+        INPUTS: properties.Schema(
+            properties.Schema.MAP,
+            _('The key/value pair inputs for the job.')),
+        TARGETS: properties.Schema(
+            properties.Schema.LIST,
+            _('A list of targets (devices) against which to execute '
+              'this job.'),
+            required=True,
+            schema=properties.Schema(
+                properties.Schema.MAP,
+                schema={
+                    DEVICE_ID: properties.Schema(
+                        properties.Schema.STRING,
+                        _('DeviceID of the device.')
+                    ),
+                    DEVICE_IP_ADDR: properties.Schema(
+                        properties.Schema.STRING,
+                        _('The IP address of the device, if not specifying '
+                          'a device ID.'),
+                        constraints=[constraints.CustomConstraint('ip_addr')]
+                    ),
+                    NETWORK_VIEW: properties.Schema(
+                        properties.Schema.STRING,
+                        _('The network view name for this device IP. Required '
+                          'if specifying an IP and there are multiple network '
+                          'views in the NetMRI.')
+                    ),
+                })),
+    }
+
+    attributes_schema = {
+        JOB: attributes.Schema(
+            _('The job object as returned by the NetMRI API.'),
+            attributes.Schema.MAP
+        ),
+        JOB_DETAILS: attributes.Schema(
+            _('A list of targets with details about each.'),
+            attributes.Schema.LIST
+        )
+    }
+
+    @property
+    def netmri(self):
+        if not getattr(self, 'netmri_object', None):
+            self.netmri_object = netmri.InfobloxNetMRI(
+                self.properties[constants.CONNECTION]
+            )
+        return self.netmri_object
+
+    def _device_ids(self):
+        ids = set()
+        ips = set()
+        view_names = set()
+        need_all_views = False
+        need_lookup = []
+        for t in self.properties[self.TARGETS]:
+            device_id = t.get(self.DEVICE_ID, None)
+            if device_id:
+                ids.add(device_id)
+            else:
+                ip = t.get(self.DEVICE_IP_ADDR, None)
+                if ip is None:
+                    continue
+                ips.add(ip)
+                view_name = t.get(self.NETWORK_VIEW, None)
+                if view_name is None:
+                    need_all_views = True
+                elif not need_all_views:
+                    view_names.add(view_name)
+                need_lookup.append([ip, view_name])
+
+        if len(ips) > 0:
+            ips = list(ips)
+
+            # pull back all the used views by name, so we can have the IDs
+            api_params = {'select': ['VirtualNetworkID', 'VirtualNetworkName']}
+            if not need_all_views:
+                api_params['VirtualNetworkName'] = list(view_names)
+            views = self.netmri.api_request('virtual_networks/search',
+                                            api_params)['virtual_networks']
+
+            # map name -> ID for the views
+            view_map = {}
+            for nv in views:
+                view_map[nv['VirtualNetworkName']] = nv['VirtualNetworkID']
+
+            # for all the targets that needed lookup, map name to ID
+            for t in need_lookup:
+                if t[1] is not None:
+                    if t[1] in view_map:
+                        t[1] = view_map[t[1]]
+                    else:
+                        raise ValueError("Network View '%s' does not exist."
+                                         % t[1])
+
+            # create a map of IP -> [ views IDs ] found in the NetMRI
+            # so we know all views in which an IP is found
+            devices = self.netmri.api_request('devices/index', {
+                'DeviceIPDotted': ips,
+                'VirtualNetworkID': list(view_map.values()),
+                'select': 'DeviceID,DeviceIPDotted,VirtualNetworkID'
+            })
+            device_map = {}
+            for dev in devices['devices']:
+                ip = dev['DeviceIPDotted']
+                if ip not in device_map:
+                    device_map[ip] = {}
+                device_map[ip][dev['VirtualNetworkID']] = dev['DeviceID']
+
+            # now, go through each target that needed lookup and find the right
+            # DeviceID that goes with that IP/view combination. If there was no
+            # view specified, there could be multiple devices corresponding to
+            # the IP - that would be an error
+            for t in need_lookup:
+                if t[1] is None and len(device_map[t[0]]) > 2:
+                    raise ValueError("No network view specified for target IP "
+                                     "%s, and that IP exists in %d different "
+                                     "views." % (t[0],
+                                                 len(device_map[t[0]]) / 2))
+                elif t[1]:
+                    ids.add(device_map[t[0]][t[1]])
+                else:
+                    ips.add(device_map[t[0]].values()[0])
+
+        return list(ids)
+
+    def handle_create(self):
+        params = {}
+        script = self.properties[self.SOURCE][self.SCRIPT]
+        if script.isdigit():
+            params['id'] = script
+        else:
+            params['name'] = script
+
+        params['device_ids'] = self._device_ids()
+
+        raw_inputs = self.properties[self.INPUTS] or {}
+        inputs = {}
+        for var in raw_inputs:
+            if var.startswith('$'):
+                inputs[var] = raw_inputs[var]
+            else:
+                inputs['$' + var] = raw_inputs[var]
+
+        params.update(inputs)
+
+        r = self.netmri.api_request('scripts/run', params)
+        self.resource_id_set(r['JobID'])
+
+    def check_create_complete(self, handler_data):
+        if not self.properties[self.WAIT]:
+            return True
+
+        job = self.netmri.show('job', int(self.resource_id))
+        LOG.debug("job = %s", job)
+        if job['completed_at']:
+            return True
+
+        return False
+
+    def handle_delete(self):
+        pass
+
+    def _get_job_details(self):
+        details = self.netmri.api_request('job_details/index',
+                                          {'id': self.resource_id})
+        device_ids = map(lambda x: x['DeviceID'], details['job_details'])
+        devices = self.netmri.api_request('devices/index',
+                                          {'DeviceID': device_ids})
+        dev_map = dict(map(lambda x: (x['DeviceID'], x), devices['devices']))
+        for detail in details['job_details']:
+            detail['device'] = dev_map.get(detail['DeviceID'], None)
+        return details['job_details']
+
+    def _resolve_attribute(self, name):
+        LOG.debug("attr '%s' for resource %s", name, self.resource_id)
+
+        if name == self.JOB:
+            job = self.netmri.show('job', int(self.resource_id))
+            return job
+
+        if name == self.JOB_DETAILS:
+            return self._get_job_details()
+
+        return
+
+
+def resource_mapping():
+    return {
+        'Infoblox::NetMRI::Job': NetMRIJob,
+    }

--- a/heat_infoblox/tests/test_resource_utils.py
+++ b/heat_infoblox/tests/test_resource_utils.py
@@ -28,16 +28,11 @@ class ResourceUtilsTest(common.HeatTestCase):
 
     def test_wapi_config_file(self):
 
-        for opt in ['wapi_url', 'username', 'password']:
-            cfg.CONF.set_override(name=opt,
-                                  override='test_%s' % opt,
-                                  group='infoblox')
-
-        cfg.CONF.set_override(name='sslverify',
-                              override=False,
-                              group='infoblox')
         connector.Infoblox = mock.MagicMock()
-        resource_utils.connect_to_infoblox()
+        resource_utils.connect_to_infoblox({'url': 'test_wapi_url',
+                                            'username': 'test_username',
+                                            'password': 'test_password',
+                                            'sslverify': False})
         connector.Infoblox.assert_called_with({'url': 'test_wapi_url',
                                                'username': 'test_username',
                                                'password': 'test_password',

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-pbr!=0.7,<1.0,>=0.6
-Babel<=1.3,>=1.3
--e git+https://git.openstack.org/openstack/heat.git@stable/kilo#egg=heat
+pbr<2.0,>=1.4
+Babel>=1.3
+oslo.config>=2.6.0 # Apache-2.0
+infoblox-netmri>=0.1.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,13 +6,13 @@
 hacking<0.11,>=0.10.0
 coverage>=3.6
 discover
-mock<1.1.0,>=1.0
+-e git+https://git.openstack.org/openstack/heat.git@stable/kilo#egg=heat
+mock>=1.2
 mox>=0.5.3
-MySQL-python
-oslosphinx<2.6.0,>=2.5.0 # Apache-2.0
-oslotest<1.6.0,>=1.5.1 # Apache-2.0
+mox3>=0.7.0
+oslosphinx>=2.5.0 # Apache-2.0
+oslotest>=1.10.0 # Apache-2.0
 paramiko>=1.13.0
-psycopg2
 sphinx!=1.2.0,!=1.3b1,<1.3,>=1.1.2
 testrepository>=0.0.18
 testscenarios>=0.4


### PR DESCRIPTION
Change the WAPI connection info to be kept in the template file,
like is done with netmri_job.py. Created a common class to manage
both API connections.

Cherry-picked from commit 8f91a28a4a1b17bb3748b0a47931b4b08b8efb68
