### PR TITLE
Add Anycast Loopback resource

### DIFF
--- a/heat_infoblox/resources/anycast_loopback.py
+++ b/heat_infoblox/resources/anycast_loopback.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2016 Infoblox Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import logging
+
+from heat.common.i18n import _
+from heat.engine import properties
+from heat.engine import resource
+from heat.engine import support
+
+from heat_infoblox import constants
+from heat_infoblox import resource_utils
+
+
+LOG = logging.getLogger(__name__)
+
+
+class AnycastLoopback(resource.Resource):
+    """A resource which represents an anycast loopback interface.
+
+    This is used to assign anycast address to Grid Member loopback interface.
+    """
+
+    PROPERTIES = (
+        IP, GRID_MEMBERS, ENABLE_BGP, ENABLE_OSPF,
+        ) = (
+        'ip', 'grid_members', 'enable_bgp', 'enable_ospf',
+        )
+
+    support_status = support.SupportStatus(
+        support.UNSUPPORTED,
+        _('See support.infoblox.com for support.'))
+
+    properties_schema = {
+        constants.CONNECTION:
+            resource_utils.connection_schema(constants.DDI),
+        IP: properties.Schema(
+            properties.Schema.STRING,
+            _('The Anycast Loopback IP address.'),
+            required=True),
+        GRID_MEMBERS: properties.Schema(
+            properties.Schema.LIST,
+            _('List of Grid Member Names for Anycast IP address'),
+            schema=properties.Schema(
+                properties.Schema.STRING
+            ),
+            required=True),
+        ENABLE_BGP: properties.Schema(
+            properties.Schema.BOOLEAN,
+            _('Determines if the BGP advertisement setting is enabled '
+              'for this interface or not.'),
+            required=False),
+        ENABLE_OSPF: properties.Schema(
+            properties.Schema.BOOLEAN,
+            _('Determines if the OSPF advertisement setting is enabled '
+              'for this interface or not.'),
+            required=False),
+    }
+
+    @property
+    def infoblox(self):
+        if not getattr(self, 'infoblox_object', None):
+            conn = self.properties[constants.CONNECTION]
+            self.infoblox_object = resource_utils.connect_to_infoblox(conn)
+        return self.infoblox_object
+
+    def handle_create(self):
+        for member_name in self.GRID_MEMBERS:
+            self.infoblox.create_anycast_loopback(member_name,
+                                                  self.IP,
+                                                  self.ENABLE_BGP,
+                                                  self.ENABLE_OSPF)
+        self.resource_id_set(self.IP)
+
+    def handle_delete(self):
+        ip = self.resource_id
+        if ip is not None:
+            self.infoblox.delete_anycast_loopback(ip)
+
+
+def resource_mapping():
+    return {
+        'Infoblox::Grid::AnycastLoopback': AnycastLoopback,
+    }

--- a/heat_infoblox/tests/test_object_manipulator.py
+++ b/heat_infoblox/tests/test_object_manipulator.py
@@ -1,0 +1,143 @@
+# Copyright 2016 Infoblox Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+import mock
+import testtools
+
+from heat_infoblox import object_manipulator
+
+MEMBER_WITH_ANYCAST_IP = {
+    '_ref': u'member/b25lLnZpcnR1YWxfbm9kZSQw:master-113.ft-ac.com',
+    'additional_ip_list': [{
+        'anycast': True,
+        'enable_bgp': False,
+        'enable_ospf': False,
+        'interface': u'LOOPBACK',
+        'ipv4_network_setting': {
+            'address': u'172.252.5.2',
+            'dscp': 0,
+            'primary': False,
+            'subnet_mask': u'255.255.255.255',
+            'use_dscp': False}}]}
+
+
+class TestObjectManipulator(testtools.TestCase):
+
+    def _test_create_anycast_loopback(self, ip, expected_anycast_dict):
+        member_name = 'member_name'
+        connector = mock.Mock()
+        connector.get_object.return_value = [MEMBER_WITH_ANYCAST_IP]
+
+        om = object_manipulator.InfobloxObjectManipulator(connector)
+        om.create_anycast_loopback(member_name, ip, enable_bgp=True,
+                                   enable_ospf=True)
+
+        connector.get_object.assert_called_once_with(
+            'member', {'host_name': member_name},
+            ['additional_ip_list'], extattrs=None)
+
+        expected_ip_list = MEMBER_WITH_ANYCAST_IP['additional_ip_list'][:]
+        expected_ip_list.append(expected_anycast_dict)
+        connector.update_object.assert_called_once_with(
+            MEMBER_WITH_ANYCAST_IP['_ref'],
+            {'additional_ip_list': expected_ip_list})
+
+    def test_create_anycast_loopback_v4(self):
+        ip = '172.23.25.25'
+        expected_anycast_dict = {'anycast': True,
+                                 'ipv4_network_setting':
+                                     {'subnet_mask': '255.255.255.255',
+                                      'address': ip},
+                                 'enable_bgp': True,
+                                 'interface': 'LOOPBACK',
+                                 'enable_ospf': True}
+        self._test_create_anycast_loopback(ip, expected_anycast_dict)
+
+    def test_create_anycast_loopback_v6(self):
+        ip = 'fffe::5'
+        expected_anycast_dict = {'anycast': True,
+                                 'ipv6_network_setting':
+                                     {'virtual_ip': ip},
+                                 'enable_bgp': True,
+                                 'interface': 'LOOPBACK',
+                                 'enable_ospf': True}
+        self._test_create_anycast_loopback(ip, expected_anycast_dict)
+
+    def _test_delete_anycast_loopback(self, ip, members, expected_calls):
+        connector = mock.Mock()
+        connector.get_object.return_value = members
+
+        om = object_manipulator.InfobloxObjectManipulator(connector)
+        om.delete_anycast_loopback(ip)
+
+        connector.get_object.assert_called_once_with(
+            'member', return_fields=['additional_ip_list'])
+        connector.update_object.assert_has_calls(expected_calls)
+
+    def test_delete_anycast_loopback_single_anycast(self):
+        ip = '172.23.25.25'
+        members = [
+            {'_ref': u'member/a25lL2ecnR1YWxfbm9kZSQw:master-113.ft-ac.com',
+             'additional_ip_list': [{'anycast': True,
+                                     'ipv4_network_setting':
+                                         {'subnet_mask': '255.255.255.255',
+                                          'address': ip},
+                                     'enable_bgp': True,
+                                     'interface': 'LOOPBACK',
+                                     'enable_ospf': True}]},
+            {'_ref': u'member/cnR1YWxf:master-host.infoblox.com',
+             'additional_ip_list': [{'anycast': True,
+                                     'ipv4_network_setting':
+                                         {'subnet_mask': '255.255.255.255',
+                                          'address': ip},
+                                     'enable_bgp': True,
+                                     'interface': 'LOOPBACK',
+                                     'enable_ospf': True}]},
+            MEMBER_WITH_ANYCAST_IP]
+        # update should be called only for the first two members,
+        # where anycast ip matches
+        expected_calls = [
+            mock.call(members[0]['_ref'], {'additional_ip_list': []}),
+            mock.call(members[1]['_ref'], {'additional_ip_list': []})]
+        self._test_delete_anycast_loopback(ip, members, expected_calls)
+
+    def test_delete_anycast_loopback_multiple_anycast(self):
+        ip = '172.23.25.25'
+        members = [
+            {'_ref': u'member/a25lLnZpcnR1YWxfbm9kZSQw:master-113.ft-ac.com',
+             'additional_ip_list': [
+                 {'anycast': True,
+                  'ipv4_network_setting':
+                      {'subnet_mask': '255.255.255.255',
+                       'address': ip},
+                  'enable_bgp': True,
+                  'interface': 'LOOPBACK',
+                  'enable_ospf': True},
+                 MEMBER_WITH_ANYCAST_IP['additional_ip_list'][0]]},
+            {'_ref': u'member/cnR1YWxf:master-host.infoblox.com',
+             'additional_ip_list': [{'anycast': True,
+                                     'ipv4_network_setting':
+                                         {'subnet_mask': '255.255.255.255',
+                                          'address': ip},
+                                     'enable_bgp': True,
+                                     'interface': 'LOOPBACK',
+                                     'enable_ospf': True}]}]
+        expected_calls = [
+            mock.call(members[0]['_ref'],
+                      {'additional_ip_list':
+                          MEMBER_WITH_ANYCAST_IP['additional_ip_list']}),
+            mock.call(members[1]['_ref'], {'additional_ip_list': []})]
+        self._test_delete_anycast_loopback(ip, members, expected_calls)


### PR DESCRIPTION
AnycastLoopback resource is used to assign anycast address to
loopback interface of multiple Grid Members.

Added create_anycast_loopback and delete_anycast_loopback methods to
object manipulator and covered them with Unit Tests.
create_anycast_loopback method adds loopback interface to member preserving
existent anycast configuration
delete_anycast_loopback deletes anycast interface that matches by ip
from list of anycast interfaces for member. By default deletes anycast
ip from all members. If member_name is passed deletes anycast interface
from single member.
