### PR TITLE
Use two argument form for support_status

### DIFF
--- a/heat_infoblox/resources/netmri_job.py
+++ b/heat_infoblox/resources/netmri_job.py
@@ -53,7 +53,9 @@ class NetMRIJob(resource.Resource):
         'job_details'
     )
 
-    support_status = support.SupportStatus(support.UNSUPPORTED)
+    support_status = support.SupportStatus(
+        support.UNSUPPORTED,
+        _('See support.infoblox.com for support.'))
 
     properties_schema = {
         constants.CONNECTION:


### PR DESCRIPTION
Using one argument form for support_status caused failure on parsing
NetMRIJob resource for stable/kilo.
Fixing it by switching to two argument form.

Closes: #10
