### PR TITLE
Store members as identifier for AnycastLoopback

### DIFF
--- a/heat_infoblox/object_manipulator.py
+++ b/heat_infoblox/object_manipulator.py
@@ -111,6 +111,7 @@ class InfobloxObjectManipulator(object):
             LOG.error(_("Grid Member %(name)s is not found, can not assign "
                         "Anycast Loopback ip %(ip)s"),
                       {'name': member_name, 'ip': ip})
+            return
         additional_ip_list = member['additional_ip_list'] + [anycast_loopback]
 
         payload = {'additional_ip_list': additional_ip_list}


### PR DESCRIPTION
AnycastLoopback identifier is now stored in next format:
'ip/member1/member2/member3'
So on handle_delete list of members is available.
Also fixed issue with retrieving parameter values.
