### PR TITLE
Set defaults for AnycastLoopback template

### DIFF
--- a/doc/templates/anycast-loopback.yaml
+++ b/doc/templates/anycast-loopback.yaml
@@ -10,9 +10,11 @@ parameters:
   enable_bgp:
     type: boolean
     description: Determines if the BGP advertisement setting is enabled for this interface or not.
+    default: False
   enable_ospf:
     type: boolean
     description: Determines if the OSPF advertisement setting is enabled for this interface or not.
+    default: False
 resources:
   anycast:
     type: Infoblox::Grid::AnycastLoopback


### PR DESCRIPTION
Add default=False for enable_bgp and enable_ospf.
Without it user had to set them to True.
