### PR TITLE
Add 'cidr_prefix' field for ipv6 anycast address

### DIFF
--- a/heat_infoblox/object_manipulator.py
+++ b/heat_infoblox/object_manipulator.py
@@ -96,7 +96,8 @@ class InfobloxObjectManipulator(object):
             'interface': 'LOOPBACK'}
         if ':' in ip:
             anycast_loopback['ipv6_network_setting'] = {
-                'virtual_ip': ip}
+                'virtual_ip': ip,
+                'cidr_prefix': 128}
         else:
             anycast_loopback['ipv4_network_setting'] = {
                 'address': ip,

--- a/heat_infoblox/tests/test_object_manipulator.py
+++ b/heat_infoblox/tests/test_object_manipulator.py
@@ -71,7 +71,8 @@ class TestObjectManipulator(testtools.TestCase):
         ip = 'fffe::5'
         expected_anycast_dict = {'anycast': True,
                                  'ipv6_network_setting':
-                                     {'virtual_ip': ip},
+                                     {'virtual_ip': ip,
+                                      'cidr_prefix': 128},
                                  'enable_bgp': True,
                                  'interface': 'LOOPBACK',
                                  'enable_ospf': True}


### PR DESCRIPTION
Anycast loopback was failing on creating ipv6 addresses. It happened
because cidr prefix was not send over wapi. For ipv6 addresses assigned
to loopback interface cidr_prefix has to be '128'.

Added 'cidr_prefix' to create_anycast_loopback method and updated tests
accordingly.
