### PR TITLE
Fix OSPF resource

### DIFF
--- a/heat_infoblox/object_manipulator.py
+++ b/heat_infoblox/object_manipulator.py
@@ -170,17 +170,51 @@ class InfobloxObjectManipulator(object):
         self._update_infoblox_object('nsgroup', {'name': group_name},
                                      group)
 
+    @staticmethod
+    def _copy_fields_or_raise(source_dict, dest_dict, fields):
+        for field in fields:
+            if field not in source_dict:
+                raise ValueError(_("Field '{}' is required").format(field))
+            else:
+                dest_dict[field] = source_dict[field]
+
     def create_ospf(self, member_name, ospf_options_dict):
         """Add ospf settings to the grid member."""
+        required_fields = ('area_id', 'area_type', 'auto_calc_cost_enabled',
+                           'authentication_type', 'is_ipv4', 'interface')
+        optional_fields = ('comment', 'dead_interval', 'hello_interval',
+                           'interface', 'retransmit_interval',
+                           'transmit_delay')
+        opts = {}
+        self._copy_fields_or_raise(ospf_options_dict, opts, required_fields)
+
+        conditional_fields = []
+        # Process fields that become required depending on another field value
+        if opts['auto_calc_cost_enabled'] is False:
+            conditional_fields.append('cost')
+        if opts['interface'] == 'IP':
+            conditional_fields.append('advertise_interface_vlan')
+
+        if opts['authentication_type'] == 'MESSAGE_DIGEST':
+            conditional_fields.extend(['authentication_key', 'key_id'])
+        elif opts['authentication_type'] == 'SIMPLE':
+            conditional_fields.append('authentication_key')
+        self._copy_fields_or_raise(ospf_options_dict, opts, conditional_fields)
+
+        # Copy optional fields if value is set
+        for field in optional_fields:
+            if ospf_options_dict.get(field):
+                opts[field] = ospf_options_dict[field]
+
         member = self._get_infoblox_object_or_none(
             'member', {'host_name': member_name},
             return_fields=['ospf_list'])
 
-        # Should we raise some exception here or just log object not found?
         if not member:
             LOG.error(_("Grid Member %(name)s is not found"),
                       {'name': member_name})
-        ospf_list = member['ospf_list'] + [ospf_options_dict]
+            return
+        ospf_list = member['ospf_list'] + [opts]
         payload = {'ospf_list': ospf_list}
         self._update_infoblox_object_by_ref(member['_ref'], payload)
 

--- a/heat_infoblox/resources/ospf.py
+++ b/heat_infoblox/resources/ospf.py
@@ -142,25 +142,16 @@ class Ospf(resource.Resource):
         return self.infoblox_object
 
     def handle_create(self):
-        exclude_props = (self.GRID_MEMBERS,)
         ospf_options_dict = {
-            name: getattr(self, name) for name in self.PROPERTIES
-            if getattr(self, name) is not None and name not in exclude_props}
-        for member_name in self.GRID_MEMBERS:
+            name: self.properties.get(name) for name in self.PROPERTIES}
+        for member_name in self.properties[self.GRID_MEMBERS]:
             self.infoblox.create_ospf(member_name,
                                       ospf_options_dict)
-        identifiers = [self.AREA_ID] + self.GRID_MEMBERS
-        resource_id = self.DELIM.join(identifiers)
-        self.resource_id_set(resource_id)
+        self.resource_id_set(self.properties[self.AREA_ID])
 
     def handle_delete(self):
-        if self.resource_id:
-            identifiers = self.resource_id.split(self.DELIM)
-            if len(identifiers) > 1:
-                area_id = identifiers[0]
-                members = identifiers[1:]
-                for member in members:
-                    self.infoblox.delete_ospf(area_id, member)
+        for member in self.properties[self.GRID_MEMBERS]:
+            self.infoblox.delete_ospf(self.properties[self.AREA_ID], member)
 
 
 def resource_mapping():


### PR DESCRIPTION
Reworked create_ospf method to validate fields from input and build
data dict that include only fields expected by wapi.

Resource properties are available on delete stage, so no need to
overload resource_id field with that data any more. Reworked
handle_create and handle_delete accordingly.
