### PR TITLE
Replace hardcoded path for 'plugin_dirs'

### DIFF
--- a/heat_infoblox/tests/test_grid_member.py
+++ b/heat_infoblox/tests/test_grid_member.py
@@ -15,11 +15,9 @@
 
 import copy
 import mock
+import os
 
 from oslo_config import cfg
-
-cfg.CONF.import_opt('plugin_dirs', 'heat.common.config')
-cfg.CONF.set_override('plugin_dirs', '/opt/stack/heat-infoblox/heat_infoblox')
 
 from heat.engine import stack
 from heat.engine import template
@@ -44,9 +42,15 @@ grid_member_template = {
     }
 }
 
+DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+
 
 class GridMemberTest(common.HeatTestCase):
     def setUp(self):
+        heat_infoblox_path = os.path.abspath(os.path.join(
+            os.path.dirname(__file__), os.pardir))
+        cfg.CONF.import_opt('plugin_dirs', 'heat.common.config')
+        cfg.CONF.set_override('plugin_dirs', heat_infoblox_path)
         super(GridMemberTest, self).setUp()
 
         self.ctx = utils.dummy_context()

--- a/heat_infoblox/tests/test_nameserver_group_member.py
+++ b/heat_infoblox/tests/test_nameserver_group_member.py
@@ -14,11 +14,9 @@
 #    under the License.
 
 import mock
+import os
 
 from oslo_config import cfg
-
-cfg.CONF.import_opt('plugin_dirs', 'heat.common.config')
-cfg.CONF.set_override('plugin_dirs', '/opt/stack/heat-infoblox/heat_infoblox')
 
 from heat.engine import stack
 from heat.engine import template
@@ -44,6 +42,10 @@ my_template = {
 
 class NameServerGroupMemberTest(common.HeatTestCase):
     def setUp(self):
+        heat_infoblox_path = os.path.abspath(os.path.join(
+            os.path.dirname(__file__), os.pardir))
+        cfg.CONF.import_opt('plugin_dirs', 'heat.common.config')
+        cfg.CONF.set_override('plugin_dirs', heat_infoblox_path)
         super(NameServerGroupMemberTest, self).setUp()
 
         self.ctx = utils.dummy_context()


### PR DESCRIPTION
Old path for plugin_dirs worked correctly only for devstack
installation.
To make code testable in other environments (like local machine or
Travis CI) static path was replaced with dynamic path building
by os.path module.
