### PR TITLE
Add BGP AS and BGP Neighbor resources

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,11 +30,16 @@ OpenStack Configuration
 
 You must update the ``plugin_dirs`` parameter in the ``heat.conf`` file
 to include the resources from this module. Typically this would mean
-adding ``/usr/local/lib/python2.7/dist-packages/heat_infoblox``:
-
+adding ``/usr/local/lib/python2.7/dist-packages/heat_infoblox``.
+Also you must add ``lock_path`` under ``oslo_concurrency`` stanza.
+For security, the specified directory should only be writable by the user
+running the heat process:
 ::
 
   plugin_dirs = /usr/local/lib/python2.7/dist-packages/heat_infoblox,/usr/lib64/heat,/usr/lib/heat
+  [oslo_concurrency]
+  # replace it with a directory writable by the user running the heat process
+  lock_path = /home/user/directory_for_locks
 
 The Heat engine must be restarted after installation and configuration of the
 package.

--- a/doc/templates/bgp-neighbor-settings.yaml
+++ b/doc/templates/bgp-neighbor-settings.yaml
@@ -1,0 +1,48 @@
+heat_template_version: 2014-10-16
+description: Template to configure BGP settings on existent Grid
+parameters:
+  grid_member:
+    type: string
+    description: Grid Member Name for BGP Neigbor configuration
+  authentication_mode:
+    type: string
+    description: >
+      Determines the BGP authentication mode.
+      ('MD5', 'NONE').
+    default: 'NONE'
+  bgp_neighbor_pass:
+    type: string
+    description: >
+      The password for a BGP neighbor. This is required only if
+      authentication_mode is set to "MD5".
+    default: ''
+  comment:
+    type: string
+    description: User comments for this BGP neighbor.
+    default: ''
+  interface:
+    type: string
+    description: >
+      The interface that sends BGP advertisement information.
+      ('LAN_HA')
+    default: 'LAN_HA'
+  neighbor_ip:
+    type: string
+    description: The IP address of the BGP neighbor.
+  remote_as:
+    type: number
+    description: The remote AS number of the BGP neighbor.
+    constraints:
+      - range: { min: 0, max: 65535 }
+resources:
+  bgp_neighbor:
+    type: Infoblox::Grid::BgpNeighbor
+    properties:
+      connection: { url: "https://10.40.240.113/wapi/v2.3/", username: admin, password: infoblox, sslverify: False }
+      grid_member: { get_param: grid_member }
+      authentication_mode: { get_param: authentication_mode }
+      bgp_neighbor_pass: { get_param: bgp_neighbor_pass }
+      comment: { get_param: comment }
+      interface: { get_param: interface }
+      neighbor_ip: { get_param: neighbor_ip }
+      remote_as: { get_param: remote_as }

--- a/doc/templates/bgp-with-two-neighbors.yaml
+++ b/doc/templates/bgp-with-two-neighbors.yaml
@@ -1,0 +1,115 @@
+heat_template_version: 2014-10-16
+description: Template to configure BGP settings on existent Grid
+parameters:
+  grid_member:
+    type: string
+    description: Grid Member Name for BGP Neigbor configuration
+  as:
+    type: number
+    description: The number of this autonomous system.
+    constraints:
+      - range: { min: 0, max: 65535 }
+  holddown:
+    type: number
+    description: >
+      The AS holddown timer (in seconds).
+      The valid value is from 3 to 65535.
+    default: 16
+  keepalive:
+    type: number
+    description: >
+      The AS keepalive timer (in seconds). The valid value is
+      from 1 to 21845.The AS holddown timer (in seconds).
+    default: 4
+  link_detect:
+    type: boolean
+    description: Determines if link detection on the interface is enabled.
+    default: False
+  authentication_mode_n1:
+    type: string
+    description: >
+      Determines the BGP authentication mode.
+      ('MD5', 'NONE').
+    default: 'NONE'
+  bgp_neighbor_pass_n1:
+    type: string
+    description: >
+      The password for a BGP neighbor. This is required only if
+      authentication_mode is set to "MD5".
+    default: ''
+  comment_n1:
+    type: string
+    description: User comments for this BGP neighbor.
+    default: ''
+  interface_n1:
+    type: string
+    description: >
+      The interface that sends BGP advertisement information.
+      ('LAN_HA')
+    default: 'LAN_HA'
+  neighbor_ip_n1:
+    type: string
+    description: The IP address of the BGP neighbor.
+  remote_as_n1:
+    type: number
+    description: The remote AS number of the BGP neighbor.
+    constraints:
+      - range: { min: 0, max: 65535 }
+  authentication_mode_n2:
+    type: string
+    description: >
+      Determines the BGP authentication mode.
+      ('MD5', 'NONE').
+    default: 'NONE'
+  bgp_neighbor_pass_n2:
+    type: string
+    description: >
+      The password for a BGP neighbor. This is required only if
+      authentication_mode is set to "MD5".
+    default: ''
+  comment_n2:
+    type: string
+    description: User comments for this BGP neighbor.
+    default: ''
+  interface_n2:
+    type: string
+    description: >
+      The interface that sends BGP advertisement information.
+      ('LAN_HA')
+    default: 'LAN_HA'
+  neighbor_ip_n2:
+    type: string
+    description: The IP address of the BGP neighbor.
+  remote_as_n2:
+    type: number
+    description: The remote AS number of the BGP neighbor.
+    constraints:
+      - range: { min: 0, max: 65535 }
+resources:
+  bgp:
+    type: Infoblox::Grid::Bgp
+    properties:
+      connection: { url: "https://10.40.240.113/wapi/v2.3/", username: admin, password: infoblox, sslverify: False }
+      grid_member: { get_param: grid_member }
+      as: { get_param: as }
+      holddown: { get_param: holddown }
+      keepalive: { get_param: keepalive }
+      link_detect: { get_param: link_detect }
+      authentication_mode: { get_param: authentication_mode_n1 }
+      bgp_neighbor_pass: { get_param: bgp_neighbor_pass_n1 }
+      comment: { get_param: comment_n1 }
+      interface: { get_param: interface_n1 }
+      neighbor_ip: { get_param: neighbor_ip_n1 }
+      remote_as: { get_param: remote_as_n1 }
+  bgp_neighbor:
+    type: Infoblox::Grid::BgpNeighbor
+    depends_on: bgp
+    properties:
+      connection: { url: "https://10.40.240.113/wapi/v2.3/", username: admin, password: infoblox, sslverify: False }
+      grid_member: { get_param: grid_member }
+      authentication_mode: { get_param: authentication_mode_n2 }
+      bgp_neighbor_pass: { get_param: bgp_neighbor_pass_n2 }
+      comment: { get_param: comment_n2 }
+      interface: { get_param: interface_n2 }
+      neighbor_ip: { get_param: neighbor_ip_n2 }
+      remote_as: { get_param: remote_as_n2 }

--- a/heat_infoblox/ibexceptions.py
+++ b/heat_infoblox/ibexceptions.py
@@ -99,3 +99,12 @@ class NoInfobloxMemberAvailable(ResourceExhausted):
 
 class InfobloxObjectParsingError(InfobloxExceptionBase):
     message = _("Infoblox object cannot be parsed from dict: %(data)s")
+
+
+class InfobloxGridMemberNotFound(InfobloxExceptionBase):
+    message = _("Infoblox Grid Member '%(name)s' was not found.")
+
+
+class InfobloxBgpNotConfigured(InfobloxExceptionBase):
+    message = _("BGP Autonomous System is not configured on "
+                "Infoblox Grid Member '%(name)s'.")

--- a/heat_infoblox/resources/bgp.py
+++ b/heat_infoblox/resources/bgp.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2016 Infoblox Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import logging
+
+from heat.common.i18n import _
+from heat.engine import constraints
+from heat.engine import properties
+from heat.engine import resource
+from heat.engine import support
+from oslo_concurrency import lockutils
+
+from heat_infoblox import constants
+from heat_infoblox import resource_utils
+
+LOG = logging.getLogger(__name__)
+
+
+class Bgp(resource.Resource):
+    """A resource which represents a BGP AS configuration.
+
+    This resource is used configure a BGP Autonomous System on grid member.
+    """
+
+    PROPERTIES = (
+        GRID_MEMBER, AS, HOLDDOWN, KEEPALIVE, LINK_DETECT,
+        AUTHENTICATION_MODE, BGP_NEIGHBOR_PASS,
+        COMMENT, INTERFACE, NEIGHBOR_IP, REMOTE_AS
+        ) = (
+        'grid_member', 'as', 'holddown', 'keepalive', 'link_detect',
+        'authentication_mode', 'bgp_neighbor_pass',
+        'comment', 'interface', 'neighbor_ip', 'remote_as'
+        )
+
+    AUTHENTICATION_MODES = ('MD5', 'NONE')
+    INTERFACES = ('LAN_HA',)
+
+    support_status = support.SupportStatus(
+        support.UNSUPPORTED,
+        _('See support.infoblox.com for support.'))
+
+    properties_schema = {
+        constants.CONNECTION:
+            resource_utils.connection_schema(constants.DDI),
+        GRID_MEMBER: properties.Schema(
+            properties.Schema.STRING,
+            _('Grid Member Name for BGP Neigbor configuration'),
+            required=True),
+        AS: properties.Schema(
+            properties.Schema.INTEGER,
+            _('The number of this autonomous system.'),
+            update_allowed=True,
+            required=True),
+        HOLDDOWN: properties.Schema(
+            properties.Schema.INTEGER,
+            _('The AS holddown timer (in seconds). '
+              'Valid values are from 3 to 65535.'),
+            update_allowed=True),
+        KEEPALIVE: properties.Schema(
+            properties.Schema.INTEGER,
+            _('The AS keepalive timer (in seconds). Valid values are '
+              'from 1 to 21845.'),
+            update_allowed=True),
+        LINK_DETECT: properties.Schema(
+            properties.Schema.BOOLEAN,
+            _('Determines if link detection on the interface is enabled.'),
+            update_allowed=True),
+        AUTHENTICATION_MODE: properties.Schema(
+            properties.Schema.STRING,
+            _('Determines the BGP authentication mode.'),
+            constraints=[
+                constraints.AllowedValues(AUTHENTICATION_MODES)
+            ],
+            update_allowed=True,
+            required=True),
+        BGP_NEIGHBOR_PASS: properties.Schema(
+            properties.Schema.STRING,
+            _('The password for the BGP neighbor. This is required only if '
+              'authentication_mode is set to "MD5". '),
+            update_allowed=True),
+        COMMENT: properties.Schema(
+            properties.Schema.STRING,
+            _('User comments for this BGP neighbor.'),
+            update_allowed=True),
+        INTERFACE: properties.Schema(
+            properties.Schema.STRING,
+            _('The interface that sends BGP advertisement information.'),
+            update_allowed=True,
+            constraints=[
+                constraints.AllowedValues(INTERFACES)
+            ]),
+        NEIGHBOR_IP: properties.Schema(
+            properties.Schema.STRING,
+            _('The IP address of the BGP neighbor.'),
+            update_allowed=True,
+            required=True),
+        REMOTE_AS: properties.Schema(
+            properties.Schema.INTEGER,
+            _('The remote AS number of the BGP neighbor.'),
+            update_allowed=True,
+            required=True),
+    }
+
+    @property
+    def infoblox(self):
+        if not getattr(self, 'infoblox_object', None):
+            conn = self.properties[constants.CONNECTION]
+            self.infoblox_object = resource_utils.connect_to_infoblox(conn)
+        return self.infoblox_object
+
+    def handle_create(self):
+        bgp_options_dict = {
+            name: self.properties.get(name) for name in self.PROPERTIES}
+        member_name = self.properties[self.GRID_MEMBER]
+        # Create/update/delete actions are all doing read-change-update on bgp
+        # configuration for particular member.Concurrent modifications leads to
+        # missed data at scale and on bulk operations like deleting multiple
+        # bgp neighbors.
+        # Introduced semaphore to allow only one process to modify
+        # particular grid member bgp configuration.
+        with lockutils.lock(member_name,
+                            external=True,
+                            lock_file_prefix='infoblox-bgp-update'):
+            self.infoblox.create_bgp_as(member_name, bgp_options_dict)
+
+    def handle_update(self, json_snippet, tmpl_diff, prop_diff):
+        if prop_diff:
+            member_name = tmpl_diff['Properties']['grid_member']
+            with lockutils.lock(member_name,
+                                external=True,
+                                lock_file_prefix='infoblox-bgp-update'):
+                self.infoblox.create_bgp_as(
+                    member_name, tmpl_diff['Properties'],
+                    old_neighbor_ip=self.properties[self.NEIGHBOR_IP])
+
+    def handle_delete(self):
+        with lockutils.lock(self.properties[self.GRID_MEMBER],
+                            external=True,
+                            lock_file_prefix='infoblox-bgp-update'):
+            self.infoblox.delete_bgp_as(self.properties[self.GRID_MEMBER])
+
+
+def resource_mapping():
+    return {
+        'Infoblox::Grid::Bgp': Bgp,
+    }

--- a/heat_infoblox/resources/bgp_neighbor.py
+++ b/heat_infoblox/resources/bgp_neighbor.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2016 Infoblox Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import logging
+
+from heat.common.i18n import _
+from heat.engine import constraints
+from heat.engine import properties
+from heat.engine import resource
+from heat.engine import support
+from oslo_concurrency import lockutils
+
+from heat_infoblox import constants
+from heat_infoblox import resource_utils
+
+LOG = logging.getLogger(__name__)
+
+
+class BgpNeighbor(resource.Resource):
+    """A resource which represents a BGP Neighbor configuration.
+
+    This resource is used configure single BGP Neighbor on grid member. BGP
+    AS resource has to be created prior to creating neighbors.
+    """
+
+    PROPERTIES = (
+        GRID_MEMBER, AUTHENTICATION_MODE, BGP_NEIGHBOR_PASS,
+        COMMENT, INTERFACE, NEIGHBOR_IP, REMOTE_AS
+        ) = (
+        'grid_member', 'authentication_mode', 'bgp_neighbor_pass',
+        'comment', 'interface', 'neighbor_ip', 'remote_as'
+        )
+
+    AUTHENTICATION_MODES = ('MD5', 'NONE')
+    INTERFACES = ('LAN_HA',)
+
+    support_status = support.SupportStatus(
+        support.UNSUPPORTED,
+        _('See support.infoblox.com for support.'))
+
+    properties_schema = {
+        constants.CONNECTION:
+            resource_utils.connection_schema(constants.DDI),
+        GRID_MEMBER: properties.Schema(
+            properties.Schema.STRING,
+            _('Grid Member Name for BGP Neigbor configuration'),
+            required=True),
+        AUTHENTICATION_MODE: properties.Schema(
+            properties.Schema.STRING,
+            _('Determines the BGP authentication mode.'),
+            constraints=[
+                constraints.AllowedValues(AUTHENTICATION_MODES)
+            ],
+            update_allowed=True,
+            required=True),
+        BGP_NEIGHBOR_PASS: properties.Schema(
+            properties.Schema.STRING,
+            _('The password for the BGP neighbor. This is required only if '
+              'authentication_mode is set to "MD5". '),
+            update_allowed=True),
+        COMMENT: properties.Schema(
+            properties.Schema.STRING,
+            _('User comments for this BGP neighbor.'),
+            update_allowed=True),
+        INTERFACE: properties.Schema(
+            properties.Schema.STRING,
+            _('The interface that sends BGP advertisement information.'),
+            update_allowed=True,
+            constraints=[
+                constraints.AllowedValues(INTERFACES)
+            ]),
+        NEIGHBOR_IP: properties.Schema(
+            properties.Schema.STRING,
+            _('The IP address of the BGP neighbor.'),
+            update_allowed=True,
+            required=True),
+        REMOTE_AS: properties.Schema(
+            properties.Schema.INTEGER,
+            _('The remote AS number of the BGP neighbor.'),
+            update_allowed=True,
+            required=True),
+    }
+
+    @property
+    def infoblox(self):
+        if not getattr(self, 'infoblox_object', None):
+            conn = self.properties[constants.CONNECTION]
+            self.infoblox_object = resource_utils.connect_to_infoblox(conn)
+        return self.infoblox_object
+
+    def handle_create(self):
+        bgp_options_dict = {
+            name: self.properties.get(name) for name in self.PROPERTIES}
+        member_name = self.properties[self.GRID_MEMBER]
+        # Create/update/delete actions are all doing read-change-update on bgp
+        # configuration for particular member.Concurrent modifications leads to
+        # missed data at scale and on bulk operations like deleting multiple
+        # bgp neighbors.
+        # Introduced semaphore to allow only one process to modify
+        # particular grid member bgp configuration.
+        with lockutils.lock(member_name,
+                            external=True,
+                            lock_file_prefix='infoblox-bgp-update'):
+            self.infoblox.create_bgp_neighbor(member_name, bgp_options_dict)
+
+    def handle_update(self, json_snippet, tmpl_diff, prop_diff):
+        if prop_diff:
+            member_name = tmpl_diff['Properties']['grid_member']
+            with lockutils.lock(member_name,
+                                external=True,
+                                lock_file_prefix='infoblox-bgp-update'):
+                self.infoblox.create_bgp_neighbor(
+                    member_name,
+                    tmpl_diff['Properties'],
+                    old_neighbor_ip=self.properties[self.NEIGHBOR_IP])
+
+    def handle_delete(self):
+        with lockutils.lock(self.properties[self.GRID_MEMBER],
+                            external=True,
+                            lock_file_prefix='infoblox-bgp-update'):
+            self.infoblox.delete_bgp_neighbor(
+                self.properties[self.GRID_MEMBER],
+                self.properties[self.NEIGHBOR_IP])
+
+
+def resource_mapping():
+    return {
+        'Infoblox::Grid::BgpNeighbor': BgpNeighbor,
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@
 
 pbr!=0.7,<1.0,>=0.6
 Babel>=1.3
+oslo.concurrency<1.9.0,>=1.8.2 # Apache-2.0
 oslo.config<1.10.0,>=1.9.3 # Apache-2.0
 infoblox-netmri>=0.1.3


### PR DESCRIPTION
Two BGP resources are added:
- BGP AS for Autonomous System settings;
- BGP Neighbor for configuring BGP Neighbors;

Grid WAPI requires to configure at least one neighbor when BGP AS is
configured, so BGP AS contains configuration fields for one neighbor.
BGP AS has to be configured prior to configuring BGP Neighbors.
Single BGP AS can be configured per grid_member and multiple
BGP Neighbors.
When BGP AS and multiple neighbors are configured by single template,
all neighbors should have 'depend_on' field that refers to BGP_AS
resource.

To prevent concurrent modifications of bgp setting external locks are
used. Operations are locked by member_name.
To use external locks 'lock_path' option has to be configured
in heat.conf.
