### PR TITLE
Fix pep8 error

### DIFF
--- a/heat_infoblox/resources/netmri_managed_resource.py
+++ b/heat_infoblox/resources/netmri_managed_resource.py
@@ -101,6 +101,7 @@ class NetMRIManagedResource(resource.Resource, mri.NetMRIResourceMixin):
     def _resolve_attribute(self, name):
         return self._resolve_job_attribute(name)
 
+
 def resource_mapping():
     return {
         'Infoblox::NetMRI::ManagedResource': NetMRIManagedResource,


### PR DESCRIPTION
Two spaces are required by pep for separating classes and module
methods.
