### PR TITLE
Add support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "2.7"
+# command to install dependencies
+install: "pip install -r requirements.txt -r test-requirements.txt"
+# command to run tests
+script: tox

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -18,3 +18,4 @@ sphinx!=1.2.0,!=1.3b1,<1.3,>=1.1.2
 testrepository>=0.0.18
 testscenarios>=0.4
 testtools!=1.2.0,>=0.9.36
+tox>=2.1.1


### PR DESCRIPTION
Addes Travis CI config to run tests for python 2.7.
Added tox to test-requirements.
