### PR TITLE
Add 'enable_dns' field to Anycast resource

### DIFF
--- a/doc/templates/anycast-loopback.yaml
+++ b/doc/templates/anycast-loopback.yaml
@@ -15,6 +15,11 @@ parameters:
     type: boolean
     description: Determines if the OSPF advertisement setting is enabled for this interface or not.
     default: False
+  enable_dns:
+    type: boolean
+    description: Determines if the Anycast IP will be used to serve DNS.
+    default: False
+
 resources:
   anycast:
     type: Infoblox::Grid::AnycastLoopback
@@ -24,3 +29,4 @@ resources:
       grid_members: { get_param: grid_members }
       enable_bgp: { get_param: enable_bgp }
       enable_ospf: { get_param: enable_ospf }
+      enable_dns: { get_param: enable_dns }

--- a/heat_infoblox/resources/anycast_loopback.py
+++ b/heat_infoblox/resources/anycast_loopback.py
@@ -19,6 +19,7 @@ from heat.common.i18n import _
 from heat.engine import properties
 from heat.engine import resource
 from heat.engine import support
+from oslo_concurrency import lockutils
 
 from heat_infoblox import constants
 from heat_infoblox import resource_utils
@@ -34,9 +35,9 @@ class AnycastLoopback(resource.Resource):
     """
 
     PROPERTIES = (
-        IP, GRID_MEMBERS, ENABLE_BGP, ENABLE_OSPF,
+        IP, GRID_MEMBERS, ENABLE_BGP, ENABLE_OSPF, ENABLE_DNS,
         ) = (
-        'ip', 'grid_members', 'enable_bgp', 'enable_ospf',
+        'ip', 'grid_members', 'enable_bgp', 'enable_ospf', 'enable_dns',
         )
 
     support_status = support.SupportStatus(
@@ -67,6 +68,10 @@ class AnycastLoopback(resource.Resource):
             _('Determines if the OSPF advertisement setting is enabled '
               'for this interface or not.'),
             required=False),
+        ENABLE_DNS: properties.Schema(
+            properties.Schema.BOOLEAN,
+            _('Determines if the Anycast IP will be used to serve DNS.'),
+            required=False),
     }
 
     @property
@@ -79,16 +84,34 @@ class AnycastLoopback(resource.Resource):
     def handle_create(self):
         ip = self.properties[self.IP]
         for member_name in self.properties[self.GRID_MEMBERS]:
-            self.infoblox.create_anycast_loopback(
-                member_name,
-                ip,
-                self.properties[self.ENABLE_BGP],
-                self.properties[self.ENABLE_OSPF])
+            with lockutils.lock(member_name,
+                                external=True,
+                                lock_file_prefix='infoblox-anycast'):
+                self.infoblox.create_anycast_loopback(
+                    member_name,
+                    ip,
+                    self.properties[self.ENABLE_BGP],
+                    self.properties[self.ENABLE_OSPF])
+            if self.properties[self.ENABLE_DNS]:
+                with lockutils.lock(member_name,
+                                    external=True,
+                                    lock_file_prefix='infoblox-dns-ips'):
+                    self.infoblox.add_member_dns_additional_ip(member_name,
+                                                               ip)
 
     def handle_delete(self):
         ip = self.properties[self.IP]
         for member_name in self.properties[self.GRID_MEMBERS]:
-            self.infoblox.delete_anycast_loopback(ip, member_name)
+            if self.properties[self.ENABLE_DNS]:
+                with lockutils.lock(member_name,
+                                    external=True,
+                                    lock_file_prefix='infoblox-dns-ips'):
+                    self.infoblox.remove_member_dns_additional_ip(member_name,
+                                                                  ip)
+            with lockutils.lock(member_name,
+                                external=True,
+                                lock_file_prefix='infoblox-anycast'):
+                self.infoblox.delete_anycast_loopback(ip, member_name)
 
 
 def resource_mapping():


### PR DESCRIPTION
To serve DNS on Anycast IP address 'member:dns' object has to be
modified and ip address has to be added to 'additional_ip_list'.

If 'enable_dns' is set to true, additional wapi call is done on anycast
resource creation and deletion to modify 'additional_ip_list' in
'member:dns'
