### PR TITLE
Merge master to kilo

### DIFF
--- a/heat_infoblox/resources/netmri_managed_resource.py
+++ b/heat_infoblox/resources/netmri_managed_resource.py
@@ -101,6 +101,7 @@ class NetMRIManagedResource(resource.Resource, mri.NetMRIResourceMixin):
     def _resolve_attribute(self, name):
         return self._resolve_job_attribute(name)
 
+
 def resource_mapping():
     return {
         'Infoblox::NetMRI::ManagedResource': NetMRIManagedResource,


### PR DESCRIPTION
This merge contains single fix to make pep8 pass without errors.
After that fix is merged, Travis CI can be enabled for stable/kilo branch.
