### PR TITLE
Add resource HA pair support

### DIFF
--- a/heat_infoblox/connector.py
+++ b/heat_infoblox/connector.py
@@ -45,7 +45,8 @@ class Infoblox(object):
 
         reqd_opts = ['url', 'username', 'password']
         default_opts = {'http_pool_connections': 5,
-                        'http_pool_maxsize': 20}
+                        'http_pool_maxsize': 20,
+                        'max_retries': 5}
         for opt in reqd_opts + default_opts.keys():
             setattr(self, opt, options.get(opt) or default_opts.get(opt))
 
@@ -56,7 +57,7 @@ class Infoblox(object):
 
         self.session = requests.Session()
         adapter = requests.adapters.HTTPAdapter(
-            max_retries=5,
+            max_retries=self.max_retries,
             pool_connections=self.http_pool_connections,
             pool_maxsize=self.http_pool_maxsize)
         self.session.mount('http://', adapter)

--- a/heat_infoblox/resources/grid_member.py
+++ b/heat_infoblox/resources/grid_member.py
@@ -40,7 +40,7 @@ class GridMember(resource.Resource):
     PROPERTIES = (
         NAME, MODEL, LICENSES, TEMP_LICENSES,
         REMOTE_CONSOLE, ADMIN_PASSWORD,
-        MGMT_PORT, LAN1_PORT, LAN2_PORT, HA_PORT,
+        MGMT_PORT, LAN1_PORT, LAN2_PORT, HA_PORT, CONFIG_ADDR_TYPE,
         GM_IP, GM_CERTIFICATE,
         NAT_IP,
         # only 'enable' supported for now
@@ -50,10 +50,14 @@ class GridMember(resource.Resource):
         DNS_DTC_HEALTH_SOURCE, DNS_DTC_HEALTH_SOURCE_ADDRESS,
         DNS_RPZ_QNAME_WAIT_RECURSE, DNS_USE_RPZ_QNAME_WAIT_RECURSE,
         DNS_LOG_DTC_GSLB, DNS_LOG_DTC_HEALTH, DNS_UNBOUND_LOGGING_LEVEL,
+        HA_PAIR, VIP_PORT, USE_IPV4_VIP, VIRTUAL_ROUTER_ID,
+        LAN2_VIRTUAL_ROUTER_ID,
+        NODE2_MGMT_PORT, NODE2_LAN1_PORT, NODE2_LAN2_PORT, NODE2_HA_PORT,
+        VIP_VLAN_ID, VIP6_VLAN_ID, UPDATE_ALLOWED_ADDRESS_PAIRS
     ) = (
         'name', 'model', 'licenses', 'temp_licenses',
         'remote_console_enabled', 'admin_password',
-        'MGMT', 'LAN1', 'LAN2', 'HA',
+        'MGMT', 'LAN1', 'LAN2', 'HA', 'config_addr_type',
         'gm_ip', 'gm_certificate',
         'nat_ip',
         'dns', 'enable', 'recursive_resolver', 'ports',
@@ -62,14 +66,20 @@ class GridMember(resource.Resource):
         'dtc_health_source', 'dtc_health_source_address',
         'rpz_qname_wait_recurse', 'use_rpz_qname_wait_recurse',
         'log_dtc_glsb', 'log_dtc_health', 'unbound_logging_level',
+        'ha_pair', 'VIP', 'use_ipv4_vip', 'virtual_router_id',
+        'lan2_virtual_router_id',
+        'node2_MGMT', 'node2_LAN1', 'node2_LAN2', 'node2_HA',
+        'vip_vlan_id', 'vip6_vlan_id', 'update_allowed_address_pairs'
     )
 
     ATTRIBUTES = (
         USER_DATA,
+        NODE2_USER_DATA,
         NAME_ATTR,
         DNS_UNBOUND_CAPABLE
     ) = (
         'user_data',
+        'node2_user_data',
         'name',
         'is_unbound_capable'
     )
@@ -111,6 +121,11 @@ class GridMember(resource.Resource):
         'ipam',
         'vnios',
         'reporting')
+
+    ALLOWED_CONFIG_ADDR_TYPES = (
+        'IPV4',
+        'IPV6',
+        'BOTH')
 
     support_status = support.SupportStatus(
         support.UNSUPPORTED,
@@ -168,6 +183,14 @@ class GridMember(resource.Resource):
         MGMT_PORT: resource_utils.port_schema(MGMT_PORT, False),
         LAN1_PORT: resource_utils.port_schema(LAN1_PORT, True),
         LAN2_PORT: resource_utils.port_schema(LAN2_PORT, False),
+        HA_PORT: resource_utils.port_schema(HA_PORT, False),
+        CONFIG_ADDR_TYPE: properties.Schema(
+            properties.Schema.STRING,
+            _('Address configuration types.'),
+            constraints=[
+                constraints.AllowedValues(ALLOWED_CONFIG_ADDR_TYPES)
+            ],
+            default='IPV4'),
         DNS_SETTINGS: properties.Schema(
             properties.Schema.MAP,
             _('The DNS settings for this member.'),
@@ -178,12 +201,56 @@ class GridMember(resource.Resource):
                     _('If true, enable DNS on this member.'),
                     default=False
                 ),
-            })
+            }),
+        HA_PAIR: properties.Schema(
+            properties.Schema.BOOLEAN,
+            _('"True" if member should be configured as HA pair.'),
+            required=False,
+            default=False
+            ),
+        VIP_PORT: resource_utils.port_schema(VIP_PORT, False),
+        USE_IPV4_VIP: properties.Schema(
+            properties.Schema.BOOLEAN,
+            required=False,
+            default=True
+            ),
+        VIRTUAL_ROUTER_ID: properties.Schema(
+            properties.Schema.INTEGER,
+            _('Virtual Router ID. '
+              'Warning: Must be unique on the local network.'),
+            required=False,
+            ),
+        LAN2_VIRTUAL_ROUTER_ID: properties.Schema(
+            properties.Schema.INTEGER,
+            _('LAN2 Virtual Router ID. '
+              'Should set if configured a LAN2 address.'),
+            required=False,
+            ),
+        NODE2_MGMT_PORT: resource_utils.port_schema(NODE2_MGMT_PORT, False),
+        NODE2_LAN1_PORT: resource_utils.port_schema(NODE2_LAN1_PORT, False),
+        NODE2_LAN2_PORT: resource_utils.port_schema(NODE2_LAN2_PORT, False),
+        NODE2_HA_PORT: resource_utils.port_schema(NODE2_HA_PORT, False),
+        VIP_VLAN_ID: properties.Schema(
+            properties.Schema.INTEGER,
+            required=False,
+            ),
+        VIP6_VLAN_ID: properties.Schema(
+            properties.Schema.INTEGER,
+            required=False,
+            ),
+        UPDATE_ALLOWED_ADDRESS_PAIRS: properties.Schema(
+            properties.Schema.BOOLEAN,
+            required=False,
+            default=True
+            ),
     }
 
     attributes_schema = {
         USER_DATA: attributes.Schema(
             _('User data for the Nova boot process.'),
+            attributes.Schema.STRING),
+        NODE2_USER_DATA: attributes.Schema(
+            _('Node 2 user data for the Nova boot process.'),
             attributes.Schema.STRING),
         NAME_ATTR: attributes.Schema(
             _('The member name.'),
@@ -193,22 +260,28 @@ class GridMember(resource.Resource):
     def _make_network_settings(self, ip):
         subnet = self.client('neutron').show_subnet(ip['subnet_id'])['subnet']
         ipnet = netaddr.IPNetwork(subnet['cidr'])
-        return {
+        vip = {
             'address': ip['ip_address'],
             'subnet_mask': str(ipnet.netmask),
             'gateway': subnet['gateway_ip']
         }, subnet
+        if self.properties[self.VIP_VLAN_ID]:
+            vip['vlan_id'] = self.properties[self.VIP_VLAN_ID]
+        return vip
 
     def _make_ipv6_settings(self, ip):
         subnet = self.client('neutron').show_subnet(ip['subnet_id'])['subnet']
         prefix = netaddr.IPNetwork(subnet['cidr'])
         autocfg = subnet['ipv6_ra_mode'] == "slaac"
-        return {
+        vip6 = {
             'virtual_ip': ip['ip_address'],
             'cidr_prefix': int(prefix.prefixlen),
             'gateway': subnet['gateway_ip'], 'enabled': True,
             'auto_router_config_enabled': autocfg
         }, subnet
+        if self.properties[self.VIP6_VLAN_ID]:
+            vip6['vlan_id'] = self.properties[self.VIP6_VLAN_ID]
+        return vip6
 
     def infoblox(self):
         if not getattr(self, 'infoblox_object', None):
@@ -250,12 +323,40 @@ class GridMember(resource.Resource):
         name = self.properties[self.NAME]
         nat = self.properties[self.NAT_IP]
 
-        self.infoblox().create_member(name=name, mgmt=mgmt, lan1=lan1,
-                                      lan2=lan2, nat_ip=nat)
+        ha_pair = self.properties[self.HA_PAIR]
+        if ha_pair:
+            vrid = self.properties[self.VIRTUAL_ROUTER_ID]
+            lan2_vrid = self.properties[self.LAN2_VIRTUAL_ROUTER_ID]
+            vip = self._make_port_network_settings(self.VIP_PORT)
+            node1_ha = self._make_port_network_settings(self.HA_PORT)
+            node2_ha = self._make_port_network_settings(self.NODE2_HA_PORT)
+            node2_lan1 = self._make_port_network_settings(self.NODE2_LAN1_PORT)
+            node2_mgmt = self._make_port_network_settings(self.NODE2_MGMT_PORT)
+            use_ipv4_vip = self.properties[self.USE_IPV4_VIP]
+            config_addr_type = self.properties[self.CONFIG_ADDR_TYPE]
+            if self.properties[self.UPDATE_ALLOWED_ADDRESS_PAIRS]:
+                # Add 'allowed_address_pairs' to HA ports.
+                resource_utils.fix_ha_ports_mac(
+                    self.client('neutron'),
+                    vip, vrid, use_ipv4_vip,
+                    (self.properties[self.HA_PORT],
+                     self.properties[self.NODE2_HA_PORT]))
+            # Create infoblox HA pair member
+            self.infoblox().create_member(
+                name=name, config_addr_type=config_addr_type,
+                mgmt=mgmt, vip=vip, lan2=lan2, nat_ip=nat,
+                ha_pair=ha_pair, use_v4_vrrp=use_ipv4_vip,
+                node1_ha=node1_ha, node2_ha=node2_ha,
+                node1_lan1=lan1, node2_lan1=node2_lan1,
+                node2_mgmt=node2_mgmt, vrid=vrid, lan2_vrid=lan2_vrid)
+        else:
+            self.infoblox().create_member(name=name, mgmt=mgmt, vip=lan1,
+                                          lan2=lan2, nat_ip=nat)
+
         self.infoblox().pre_provision_member(
             name,
             hwmodel=self.properties[self.MODEL], hwtype='IB-VNIOS',
-            licenses=self.properties[self.LICENSES])
+            licenses=self.properties[self.LICENSES], ha_pair=ha_pair)
 
         dns = self.properties[self.DNS_SETTINGS]
         if dns:
@@ -300,7 +401,7 @@ class GridMember(resource.Resource):
             status['ipv6'] = port_settings['ipv6_subnet']['enable_dhcp']
         return status
 
-    def _make_user_data(self, member, token):
+    def _make_user_data(self, member, token, node=0):
         user_data = '#infoblox-config\n\n'
 
         temp_licenses = self.properties[self.TEMP_LICENSES]
@@ -317,7 +418,7 @@ class GridMember(resource.Resource):
 
         vip = member.get('vip_setting', None)
         ipv6 = member.get('ipv6_setting', None)
-
+        enable_ha = member.get('enable_ha', False)
         if ipv6 and not ipv6.get('enabled', False):
             ipv6 = None
 
@@ -332,7 +433,12 @@ class GridMember(resource.Resource):
             user_data += 'lan1:\n'
 
         if need_vip:
-            user_data += '  v4_addr: %s\n' % vip['address']
+            if enable_ha:
+                node_info = member.get('node_info')
+                user_data += '  v4_addr: %s\n' % node_info[
+                    node]['lan_ha_port_setting']['mgmt_lan']
+            else:
+                user_data += '  v4_addr: %s\n' % vip['address']
             user_data += '  v4_netmask: %s\n' % vip['subnet_mask']
             user_data += '  v4_gw: %s\n' % vip['gateway']
 
@@ -344,7 +450,7 @@ class GridMember(resource.Resource):
 
         if token and len(token) > 0:
             user_data += 'gridmaster:\n'
-            user_data += '  token: %s\n' % token[0]['token']
+            user_data += '  token: %s\n' % token[node]['token']
             user_data += '  ip_addr: %s\n' % self.properties[self.GM_IP]
             user_data += '  certificate: |\n    %s\n' % self.properties[
                 self.GM_CERTIFICATE
@@ -369,13 +475,17 @@ class GridMember(resource.Resource):
 
     def _resolve_attribute(self, name):
         member_name = self.resource_id
-        member = self.infoblox().get_member(
+        member = self.infoblox().get_member_obj(
             member_name,
-            return_fields=['host_name', 'vip_setting', 'ipv6_setting'])[0]
+            fail_if_no_member=True,
+            return_fields=['host_name', 'vip_setting', 'ipv6_setting',
+                           'enable_ha', 'node_info'])
         token = self._get_member_tokens(member)
         LOG.debug("MEMBER for %s = %s" % (name, member))
         if name == self.USER_DATA:
-            return self._make_user_data(member, token)
+            return self._make_user_data(member, token, 0)
+        if name == self.NODE2_USER_DATA:
+            return self._make_user_data(member, token, 1)
         if name == self.NAME_ATTR:
             return member['host_name']
         return None

--- a/heat_infoblox/resources/ha_pair.py
+++ b/heat_infoblox/resources/ha_pair.py
@@ -1,0 +1,230 @@
+# Copyright (c) 2015 Infoblox Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import httplib
+import logging
+import netaddr
+import time
+
+from heat.common.i18n import _
+from heat.engine import attributes
+from heat.engine import properties
+from heat.engine import resource
+from heat.engine import support
+
+from heat_infoblox import resource_utils
+
+
+LOG = logging.getLogger(__name__)
+
+
+class HaPair(resource.Resource):
+    '''A resource which represents an Infoblox HA pair.
+
+    This is used to combine two instances into HA pair.
+    '''
+
+    PROPERTIES = (
+        NAME, VIP_PORT, NODE1_HA_PORT, NODE2_HA_PORT,
+        NODE1_LAN1_PORT, NODE2_LAN1_PORT,
+        VIP_FLOATING_IP, NODE1_FLOATING_IP, NODE2_FLOATING_IP,
+        VIRTUAL_ROUTER_ID, NODE_WAIT_TIMEOUT, NODE_WAIT_RETRIES,
+        NODE1_ADMIN, NODE1_PASSWORD, NODE2_ADMIN, NODE2_PASSWORD,
+        UPDATE_ALLOWED_ADDRESS_PAIRS
+    ) = (
+        'name', 'vip', 'node1_ha', 'node2_ha', 'node1_lan1', 'node2_lan1',
+        'vip_floating_ip', 'node1_floating_ip', 'node2_floating_ip',
+        'virtual_router_id', 'node_wait_timeout', 'node_wait_retries',
+        'node1_admin', 'node1_password', 'node2_admin', 'node2_password',
+        'update_allowed_address_pairs'
+    )
+
+    ATTRIBUTES = (
+        NAME_ATTR,
+    ) = (
+        'name',
+    )
+
+    support_status = support.SupportStatus(
+        support.UNSUPPORTED,
+        _('See support.infoblox.com for support.'))
+
+    properties_schema = {
+        NAME: properties.Schema(
+            properties.Schema.STRING,
+            _('Member name.')),
+        VIP_PORT: resource_utils.port_schema(VIP_PORT, True),
+        NODE1_HA_PORT: resource_utils.port_schema(NODE1_HA_PORT, True),
+        NODE2_HA_PORT: resource_utils.port_schema(NODE2_HA_PORT, True),
+        NODE1_LAN1_PORT: resource_utils.port_schema(NODE1_LAN1_PORT, True),
+        NODE2_LAN1_PORT: resource_utils.port_schema(NODE2_LAN1_PORT, True),
+        VIP_FLOATING_IP: properties.Schema(
+            properties.Schema.STRING,
+            _('VIP floating IP.'),
+            required=True),
+        NODE1_FLOATING_IP: properties.Schema(
+            properties.Schema.STRING,
+            _('Node1 floating IP.'),
+            required=True),
+        NODE2_FLOATING_IP: properties.Schema(
+            properties.Schema.STRING,
+            _('Node2 floating IP.'),
+            required=True),
+        VIRTUAL_ROUTER_ID: properties.Schema(
+            properties.Schema.NUMBER,
+            _('Virtual router ID.'),
+            required=True),
+        NODE_WAIT_TIMEOUT: properties.Schema(
+            properties.Schema.NUMBER,
+            _('Timeout between node check retries.'),
+            required=False,
+            default=30),
+        NODE_WAIT_RETRIES: properties.Schema(
+            properties.Schema.NUMBER,
+            _('Node check retries count.'),
+            required=False,
+            default=50),
+        NODE1_ADMIN: properties.Schema(
+            properties.Schema.STRING,
+            _('Node1 admin member.'),
+            required=False,
+            default='admin'),
+        NODE1_PASSWORD: properties.Schema(
+            properties.Schema.STRING,
+            _('Node1 admin member password.'),
+            required=False,
+            default='infoblox'),
+        NODE2_ADMIN: properties.Schema(
+            properties.Schema.STRING,
+            _('Node2 admin member.'),
+            required=False,
+            default='admin'),
+        NODE2_PASSWORD: properties.Schema(
+            properties.Schema.STRING,
+            _('Node1 admin member password.'),
+            required=False,
+            default='infoblox'),
+        UPDATE_ALLOWED_ADDRESS_PAIRS: properties.Schema(
+            properties.Schema.BOOLEAN,
+            required=False,
+            default=True
+            ),
+    }
+
+    attributes_schema = {
+        NAME_ATTR: attributes.Schema(
+            _('The member name.'),
+            attributes.Schema.STRING)
+    }
+
+    def node(self, ip, username, password, sslverify=False, max_retries=30):
+        conn = {'url': 'https://%s/wapi/v2.3/' % ip,
+                'username': username,
+                'password': password,
+                'sslverify': sslverify,
+                'max_retries': max_retries}
+        return resource_utils.connect_to_infoblox(conn)
+
+    def _get_first_ip(self, port_name, is_ipv4=True):
+        port = self.client('neutron').show_port(
+            self.properties[port_name])['port']
+        for ip in port['fixed_ips']:
+            if ':' in ip['ip_address']:
+                if not is_ipv4:
+                    return ip
+            else:
+                if is_ipv4:
+                    return ip
+
+    def wait_for_https(self, ip):
+        retries = self.properties[self.NODE_WAIT_RETRIES]
+        timeout = self.properties[self.NODE_WAIT_TIMEOUT]
+        https = httplib.HTTPSConnection(ip)
+        while retries >= 0:
+            try:
+                https.connect()
+            except Exception:
+                time.sleep(timeout)
+                retries = retries - 1
+                LOG.debug('Waiting for HTTPS. Retry %s' % retries)
+            else:
+                return True
+        return False
+
+    def handle_create(self):
+        vip = self._get_first_ip(self.VIP_PORT)
+        ipv4_vip = vip['ip_address']
+        ipv4_node1_ha = self._get_first_ip(self.NODE1_HA_PORT)['ip_address']
+        ipv4_node2_ha = self._get_first_ip(self.NODE2_HA_PORT)['ip_address']
+        ipv4_node1_lan1 = self._get_first_ip(
+            self.NODE1_LAN1_PORT)['ip_address']
+        ipv4_node2_lan1 = self._get_first_ip(
+            self.NODE2_LAN1_PORT)['ip_address']
+        subnet = self.client('neutron').show_subnet(vip['subnet_id'])['subnet']
+        subnet_mask = str(netaddr.IPNetwork(subnet['cidr']).netmask)
+        gateway = subnet['gateway_ip']
+        vrid = self.properties[self.VIRTUAL_ROUTER_ID]
+        if self.properties[self.UPDATE_ALLOWED_ADDRESS_PAIRS]:
+            resource_utils.fix_ha_ports_mac(
+                self.client('neutron'),
+                {'ipv4': {'address': ipv4_vip}}, vrid, True,
+                (self.properties[self.NODE1_HA_PORT],
+                 self.properties[self.NODE2_HA_PORT]))
+        # Wait for node1 WAPI
+        self.wait_for_https(self.properties[self.NODE1_FLOATING_IP])
+        node1 = self.node(self.properties[self.NODE1_FLOATING_IP],
+                          self.properties[self.NODE1_ADMIN],
+                          self.properties[self.NODE1_PASSWORD])
+        ha_pair_config = {
+            'enable_ha': True,
+            'router_id': vrid,
+            'vip_setting': {
+                'address': ipv4_vip,
+                'gateway': gateway,
+                'subnet_mask': subnet_mask
+                },
+            'node_info': [
+                {
+                    'lan_ha_port_setting': {
+                        'ha_ip_address': ipv4_node1_ha,
+                        'mgmt_lan': ipv4_node1_lan1
+                    }
+                },
+                {
+                    'lan_ha_port_setting': {
+                        'ha_ip_address': ipv4_node2_ha,
+                        'mgmt_lan': ipv4_node2_lan1
+                    }
+                }
+            ]
+        }
+        node1.update_member('infoblox.localdomain', ha_pair_config)
+        # Wait for VIP and node2 WAPI
+        self.wait_for_https(self.properties[self.VIP_FLOATING_IP])
+        self.wait_for_https(self.properties[self.NODE2_FLOATING_IP])
+        node2 = self.node(self.properties[self.NODE2_FLOATING_IP],
+                          self.properties[self.NODE2_ADMIN],
+                          self.properties[self.NODE2_PASSWORD])
+        # Default grid_name is 'Infoblox' and secret is 'test'
+        # We just created VM so use default values.
+        node2.join_grid('Infoblox', ipv4_vip, 'test')
+        name = self.properties[self.NAME]
+        self.resource_id_set(name)
+
+
+def resource_mapping():
+    return {
+        'Infoblox::Grid::HaPair': HaPair,
+    }

--- a/heat_infoblox/tests/test_grid_member.py
+++ b/heat_infoblox/tests/test_grid_member.py
@@ -24,7 +24,7 @@ from heat.engine import template
 from heat.tests import common
 from heat.tests import utils
 from heat_infoblox.resources import grid_member
-
+from heat_infoblox.tests.utils import create_side_effect
 
 grid_member_template = {
     'heat_template_version': '2013-05-23',
@@ -84,6 +84,13 @@ class GridMemberTest(common.HeatTestCase):
         self.ipv4_6_member = self.base_member.copy()
         self.ipv4_6_member['ipv6_setting'] = self.ipv6_member['ipv6_setting']
 
+        self.ipv4_ha_member = self.ipv4_member.copy()
+        self.ipv4_ha_member['enable_ha'] = True
+        self.ipv4_ha_member['node_info'] = [
+            {'lan_ha_port_setting': {'mgmt_lan': '1.1.1.2'}},
+            {'lan_ha_port_setting': {'mgmt_lan': '1.1.1.3'}}
+            ]
+
     def set_stack(self, stack_template):
         self.stack = stack.Stack(
             self.ctx, 'grid_member_test_stack',
@@ -96,6 +103,9 @@ class GridMemberTest(common.HeatTestCase):
 
     def set_member(self, mem):
         self.my_member.infoblox_object.get_member.return_value = [mem]
+
+    def set_member_obj(self, mem):
+        self.my_member.infoblox_object.get_member_obj.return_value = mem
 
     def set_token(self, t):
         self.my_member._get_member_tokens.return_value = [
@@ -120,14 +130,14 @@ class GridMemberTest(common.HeatTestCase):
         self.my_member.handle_create()
         cm = self.my_member.infoblox_object.create_member
         cm.assert_called_with(name='my-name', mgmt=self._empty_ifc(),
-                              lan1=self._empty_ifc(), lan2=None, nat_ip=None)
+                              vip=self._empty_ifc(), lan2=None, nat_ip=None)
 
     def test_lan2(self):
         self.set_interface('LAN2')
         self.my_member.handle_create()
         cm = self.my_member.infoblox_object.create_member
         cm.assert_called_with(name='my-name', lan2=self._empty_ifc(),
-                              lan1=self._empty_ifc(), mgmt=None, nat_ip=None)
+                              vip=self._empty_ifc(), mgmt=None, nat_ip=None)
 
     def test_mgmt_lan2(self):
         tmpl = self.set_interface('MGMT')
@@ -135,7 +145,7 @@ class GridMemberTest(common.HeatTestCase):
         self.my_member.handle_create()
         cm = self.my_member.infoblox_object.create_member
         cm.assert_called_with(name='my-name', mgmt=self._empty_ifc(),
-                              lan1=self._empty_ifc(), lan2=self._empty_ifc(),
+                              vip=self._empty_ifc(), lan2=self._empty_ifc(),
                               nat_ip=None)
 
     def set_dns(self, dns, tmpl=None):
@@ -170,7 +180,7 @@ class GridMemberTest(common.HeatTestCase):
                          mapping['Infoblox::Grid::Member'])
 
     def test_user_data_lan1_ipv4(self):
-        self.set_member(self.ipv4_member)
+        self.set_member_obj(self.ipv4_member)
         self.set_token(['abcdefg', 'hijklmnop'])
         ud = self.my_member._resolve_attribute('user_data')
         self.assertEqual(
@@ -187,7 +197,7 @@ class GridMemberTest(common.HeatTestCase):
 
     def test_user_data_lan1_ipv4_dhcp_disabled(self):
         dhcp_status = mock.Mock(return_value={'ipv4': False, 'ipv6': True})
-        self.set_member(self.ipv4_member)
+        self.set_member_obj(self.ipv4_member)
         self.set_token(['abcdefg', 'hijklmnop'])
         self.my_member._get_dhcp_status_for_port = dhcp_status
         ud = self.my_member._resolve_attribute('user_data')
@@ -219,7 +229,7 @@ class GridMemberTest(common.HeatTestCase):
         )
 
     def test_user_data_lan1_ipv6(self):
-        self.set_member(self.ipv6_member)
+        self.set_member_obj(self.ipv6_member)
         self.set_token(['abcdefg', 'hijklmnop'])
         ud = self.my_member._resolve_attribute('user_data')
         self.assertEqual(
@@ -235,7 +245,7 @@ class GridMemberTest(common.HeatTestCase):
         )
 
     def test_user_data_lan1_ipv4_6(self):
-        self.set_member(self.ipv4_6_member)
+        self.set_member_obj(self.ipv4_6_member)
         self.set_token(['abcdefg', 'hijklmnop'])
         ud = self.my_member._resolve_attribute('user_data')
         self.assertEqual(
@@ -251,6 +261,38 @@ class GridMemberTest(common.HeatTestCase):
             '  ip_addr: 10.1.1.2\n'
             '  certificate: |\n    testing\n',
             ud
+        )
+
+    def test_user_data_ipv4_ha(self):
+        self.set_member_obj(self.ipv4_ha_member)
+        self.set_token(['abcdefg', 'hijklmnop'])
+        ud = self.my_member._resolve_attribute('user_data')
+        self.assertEqual(
+            '#infoblox-config\n\nlan1:\n'
+            '  v4_addr: 1.1.1.2\n'
+            '  v4_netmask: 255.255.255.0\n'
+            '  v4_gw: 1.1.1.1\n'
+            'gridmaster:\n'
+            '  token: abcdefg\n'
+            '  ip_addr: 10.1.1.2\n'
+            '  certificate: |\n    testing\n',
+            ud
+        )
+
+    def test_user_data2_ipv4_ha(self):
+        self.set_member_obj(self.ipv4_ha_member)
+        self.set_token(['abcdefg', 'hijklmnop'])
+        ud2 = self.my_member._resolve_attribute('node2_user_data')
+        self.assertEqual(
+            '#infoblox-config\n\nlan1:\n'
+            '  v4_addr: 1.1.1.3\n'
+            '  v4_netmask: 255.255.255.0\n'
+            '  v4_gw: 1.1.1.1\n'
+            'gridmaster:\n'
+            '  token: hijklmnop\n'
+            '  ip_addr: 10.1.1.2\n'
+            '  certificate: |\n    testing\n',
+            ud2
         )
 
     def test_temp_licenses_none(self):
@@ -327,6 +369,98 @@ class GridMemberTest(common.HeatTestCase):
         self.my_member.resource_id = None
         self.my_member.handle_create()
         self.assertEqual('my-name', self.my_member.resource_id)
+
+    def prepair_ha_pair_member(self, update_ports=True):
+        tmpl = copy.deepcopy(grid_member_template)
+        props = tmpl['resources']['my_member']['properties']
+        props['update_allowed_address_pairs'] = update_ports
+        props['admin_password'] = 'infoblox'
+        props['ha_pair'] = True
+        props['virtual_router_id'] = 123
+        props['licenses'] = ['dns', 'dhcp', 'grid']
+        ports = {
+            'VIP': {
+                'ipv4': {'address': '1.1.1.6', 'subnet_mask': '255.255.255.0',
+                         'gateway': '1.1.1.1'
+                         }
+                },
+            'LAN1': {
+                'ipv4': {'address': '1.1.1.4', 'subnet_mask': '255.255.255.0',
+                         'gateway': '1.1.1.1'
+                         }
+                },
+            'HA': {
+                'ipv4': {'address': '1.1.1.2', 'subnet_mask': '255.255.255.0',
+                         'gateway': '1.1.1.1'
+                         }
+                },
+            'node2_LAN1': {
+                'ipv4': {'address': '1.1.1.5', 'subnet_mask': '255.255.255.0',
+                         'gateway': '1.1.1.1'
+                         }
+                },
+            'node2_HA': {
+                'ipv4': {'address': '1.1.1.3', 'subnet_mask': '255.255.255.0',
+                         'gateway': '1.1.1.1'
+                         }
+                },
+            }
+        for port in ports.keys():
+            props[port] = port
+        self.set_stack(tmpl)
+        self.set_member_obj(self.ipv4_ha_member)
+        self.my_member.client = mock.MagicMock()
+        make_net_settings = mock.MagicMock()
+        make_net_settings.side_effect = create_side_effect(ports)
+        self.my_member._make_port_network_settings = make_net_settings
+        self.my_member.resource_id = None
+        clients = {'neutron': mock.MagicMock()}
+        self.my_member.client.side_effect = create_side_effect(clients)
+        return (props, clients, ports)
+
+    def test_handle_create_ha_pair(self):
+        (props, clients, ports) = self.prepair_ha_pair_member()
+        # Call 'handle_create' method
+        with mock.patch('heat_infoblox.resources.grid_member.'
+                        'resource_utils.fix_ha_ports_mac') as fix_ha_ports:
+            self.my_member.handle_create()
+            fix_ha_ports.assert_called_once_with(
+                clients['neutron'],
+                ports['VIP'],
+                props['virtual_router_id'],
+                True,
+                (props['HA'], props['node2_HA']))
+        # Check calls
+        self.assertEqual(
+            [mock.call('MGMT'), mock.call('LAN1'), mock.call('LAN2'),
+             mock.call('VIP'), mock.call('HA'), mock.call('node2_HA'),
+             mock.call('node2_LAN1'), mock.call('node2_MGMT')],
+            self.my_member._make_port_network_settings.call_args_list)
+        infoblox = self.my_member.infoblox_object
+        infoblox.create_member.assert_called_once_with(
+            config_addr_type='IPV4', ha_pair=True, lan2=None, lan2_vrid=None,
+            mgmt=None, name='my-name', nat_ip=None,
+            node1_ha=ports['HA'],
+            node1_lan1=ports['LAN1'],
+            node2_ha=ports['node2_HA'],
+            node2_lan1=ports['node2_LAN1'],
+            node2_mgmt=None, use_v4_vrrp=True,
+            vip=ports['VIP'],
+            vrid=123)
+        infoblox.pre_provision_member.assert_called_once_with(
+            'my-name', ha_pair=True, hwmodel=None, hwtype='IB-VNIOS',
+            licenses=props['licenses'])
+        infoblox.configure_member_dns.assert_not_called()
+
+    def test_update_allowed_address_pairs(self):
+        # Prepair member with update_allowed_address_pairs set to False
+        (props, clients, ports) = self.prepair_ha_pair_member(
+            update_ports=False)
+        # Call 'handle_create' method and check that fix_ha_ports not called
+        with mock.patch('heat_infoblox.resources.grid_member.'
+                        'resource_utils.fix_ha_ports_mac') as fix_ha_ports:
+            self.my_member.handle_create()
+            fix_ha_ports.assert_not_called()
 
     def test_handle_delete_none(self):
         self.set_member(self.base_member)

--- a/heat_infoblox/tests/test_ha_pair.py
+++ b/heat_infoblox/tests/test_ha_pair.py
@@ -1,0 +1,147 @@
+# Copyright 2015 Infoblox Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import mock
+import os
+
+from oslo_config import cfg
+
+from heat.engine import stack
+from heat.engine import template
+from heat.tests import common
+from heat.tests import utils
+from heat_infoblox.resources import ha_pair
+from heat_infoblox.tests.utils import create_side_effect
+
+ha_pair_template = {
+    'heat_template_version': '2013-05-23',
+    'resources': {
+        'my_ha_pair': {
+            'type': 'Infoblox::Grid::HaPair',
+            'properties': {
+                'name': 'HaPair1',
+                'vip': 'VIP',
+                'node1_ha': 'NODE1_HA',
+                'node2_ha': 'NODE2_HA',
+                'node1_lan1': 'NODE1_LAN1',
+                'node2_lan1': 'NODE2_LAN1',
+                'vip_floating_ip': 'VIP_FLOATING_IP',
+                'node1_floating_ip': 'NODE1_FLOATING_IP',
+                'node2_floating_ip': 'NODE2_FLOATING_IP',
+                'virtual_router_id': 123
+            }
+        }
+    }
+}
+
+DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+
+
+class HaPairTest(common.HeatTestCase):
+    def setUp(self):
+        heat_infoblox_path = os.path.abspath(os.path.join(
+            os.path.dirname(__file__), os.pardir))
+        cfg.CONF.import_opt('plugin_dirs', 'heat.common.config')
+        cfg.CONF.set_override('plugin_dirs', heat_infoblox_path)
+        super(HaPairTest, self).setUp()
+        self.ctx = utils.dummy_context()
+
+    def set_stack(self, stack_template):
+        self.stack = stack.Stack(
+            self.ctx, 'ha_pair_test_stack',
+            template.Template(stack_template)
+        )
+        self.my_ha_pair = self.stack['my_ha_pair']
+
+    def test_resource_mapping(self):
+        mapping = ha_pair.resource_mapping()
+        self.assertEqual(1, len(mapping))
+        self.assertEqual(ha_pair.HaPair,
+                         mapping['Infoblox::Grid::HaPair'])
+
+    def prepair_ha_pair(self, update_ports=True):
+        props = ha_pair_template['resources']['my_ha_pair']['properties']
+        props['update_allowed_address_pairs'] = update_ports
+        self.set_stack(ha_pair_template)
+        self.my_ha_pair.client = mock.MagicMock()
+        get_first_ip = mock.MagicMock()
+        ports = {
+            'vip': {'ip_address': '1.1.1.6', 'subnet_id': 'vip_subnet'},
+            'node1_lan1': {'ip_address': '1.1.1.4'},
+            'node1_ha': {'ip_address': '1.1.1.2'},
+            'node2_lan1': {'ip_address': '1.1.1.5'},
+            'node2_ha': {'ip_address': '1.1.1.3'},
+            }
+        get_first_ip.side_effect = create_side_effect(ports)
+        self.my_ha_pair._get_first_ip = get_first_ip
+        self.my_ha_pair.node = mock.MagicMock()
+        self.my_ha_pair.wait_for_https = mock.MagicMock()
+        show_subnet = mock.MagicMock()
+        show_subnet.return_value = {'subnet': {'cidr': '1.1.1.0/24',
+                                               'gateway_ip': '1.1.1.1'}}
+        neutron = mock.MagicMock()
+        neutron.show_subnet = show_subnet
+        self.my_ha_pair.client = mock.MagicMock(return_value=neutron)
+        return (props, neutron, ports)
+
+    def test_handle_create(self):
+        (props, neutron, ports) = self.prepair_ha_pair()
+        with mock.patch('heat_infoblox.resources.grid_member.'
+                        'resource_utils.fix_ha_ports_mac') as fix_ha_ports:
+            # Call 'handle_create' method
+            self.my_ha_pair.handle_create()
+            fix_ha_ports.assert_called_once_with(
+                neutron,
+                {'ipv4': {'address': ports['vip']['ip_address']}},
+                props['virtual_router_id'],
+                True,
+                (props['node1_ha'], props['node2_ha']))
+        # Check calls
+        self.assertEqual(
+            [mock.call('vip'), mock.call('node1_ha'), mock.call('node2_ha'),
+             mock.call('node1_lan1'), mock.call('node2_lan1')],
+            self.my_ha_pair._get_first_ip.mock_calls)
+        self.assertEqual(
+            [mock.call('NODE1_FLOATING_IP'), mock.call('VIP_FLOATING_IP'),
+             mock.call('NODE2_FLOATING_IP')],
+            self.my_ha_pair.wait_for_https.mock_calls)
+        self.assertEqual(
+            [mock.call('NODE1_FLOATING_IP', 'admin', 'infoblox'),
+             mock.call().update_member(
+                 'infoblox.localdomain',
+                 {'enable_ha': True, 'router_id': 123,
+                  'node_info': [
+                      {'lan_ha_port_setting': {'mgmt_lan': '1.1.1.4',
+                                               'ha_ip_address': '1.1.1.2'}},
+                      {'lan_ha_port_setting': {'mgmt_lan': '1.1.1.5',
+                                               'ha_ip_address': '1.1.1.3'}}],
+                  'vip_setting': {'subnet_mask': '255.255.255.0',
+                                  'gateway': '1.1.1.1',
+                                  'address': '1.1.1.6'}
+                  }),
+             mock.call('NODE2_FLOATING_IP', 'admin', 'infoblox'),
+             mock.call().join_grid('Infoblox', '1.1.1.6', 'test')
+             ],
+            self.my_ha_pair.node.mock_calls)
+
+    def test_update_allowed_address_pairs(self):
+        # Prepair member with update_allowed_address_pairs set to False
+        (props, neutron, ports) = self.prepair_ha_pair(
+            update_ports=False)
+        # Call 'handle_create' method and check that fix_ha_ports not called
+        with mock.patch('heat_infoblox.resources.grid_member.'
+                        'resource_utils.fix_ha_ports_mac') as fix_ha_ports:
+            self.my_ha_pair.handle_create()
+            fix_ha_ports.assert_not_called()

--- a/heat_infoblox/tests/test_resource_utils.py
+++ b/heat_infoblox/tests/test_resource_utils.py
@@ -36,3 +36,99 @@ class ResourceUtilsTest(common.HeatTestCase):
                                                'username': 'test_username',
                                                'password': 'test_password',
                                                'sslverify': False})
+
+    def test_get_vrrp_mac(self):
+        # For IPv4 should be '00:00:5E:00:01:00' with last octet = VRID
+        mac_v4 = resource_utils.get_vrrp_mac(123, True)
+        self.assertEqual(mac_v4, '00:00:5E:00:01:7B')
+        # For IPv6 should be '00:00:5E:00:02:00' with last octet = VRID
+        mac_v4 = resource_utils.get_vrrp_mac(153, True)
+        self.assertEqual(mac_v4, '00:00:5E:00:01:99')
+        # Check VRID type validation
+        self.assertRaises(ValueError, resource_utils.get_vrrp_mac, None, True)
+        self.assertRaises(ValueError, resource_utils.get_vrrp_mac, '11', True)
+
+    def test_get_ip_address(self):
+        vip = {
+            'ipv4': {'address': '1.1.1.1'},
+            'ipv6': {'virtual_ip': u'1234:5678:90ab:cdef::1'}
+            }
+        # Check get IPv4 address
+        self.assertEqual(vip['ipv4']['address'],
+                         resource_utils.get_ip_address(vip, True, 'vip'))
+        # Check get IPv6 address
+        self.assertEqual(vip['ipv6']['virtual_ip'],
+                         resource_utils.get_ip_address(vip, False, 'vip'))
+        # Check ip validation
+        vip['ipv4']['address'] = 1
+        vip['ipv6']['virtual_ip'] = None
+        self.assertRaises(ValueError, resource_utils.get_ip_address,
+                          vip, True, 'vip')
+        self.assertRaises(ValueError, resource_utils.get_ip_address,
+                          vip, False, 'vip')
+        vip['ipv4'] = None
+        vip['ipv6'] = None
+        self.assertRaises(ValueError, resource_utils.get_ip_address,
+                          vip, True, 'vip')
+        self.assertRaises(ValueError, resource_utils.get_ip_address,
+                          vip, False, 'vip')
+        vip = {}
+        self.assertRaises(ValueError, resource_utils.get_ip_address,
+                          vip, True, 'vip')
+        self.assertRaises(ValueError, resource_utils.get_ip_address,
+                          vip, False, 'vip')
+        vip = 1244
+        self.assertRaises(ValueError, resource_utils.get_ip_address,
+                          vip, True, 'vip')
+        self.assertRaises(ValueError, resource_utils.get_ip_address,
+                          vip, False, 'vip')
+        vip = None
+        self.assertRaises(ValueError, resource_utils.get_ip_address,
+                          vip, True, 'vip')
+        self.assertRaises(ValueError, resource_utils.get_ip_address,
+                          vip, False, 'vip')
+
+    def test_fix_ha_ports_mac(self):
+        neutron = mock.MagicMock()
+        vip = {
+            'ipv4': {'address': '1.1.1.1'},
+            'ipv6': {'virtual_ip': '1234:5678:90ab:cdef::1'}
+            }
+        ports = ['port_1', 'port_2']
+        vrid = 123
+        mac_addr = '00:00:5E:00:01:7B'
+        resource_utils.fix_ha_ports_mac(neutron, vip, vrid, use_ipv4=True,
+                                        ports=ports)
+        self.assertEqual(
+            [mock.call(
+                'port_1',
+                {'port': {'allowed_address_pairs': [{
+                    'ip_address': vip['ipv4']['address'],
+                    'mac_address': mac_addr}]}}),
+             mock.call(
+                 'port_2',
+                 {'port': {'allowed_address_pairs': [{
+                     'ip_address': vip['ipv4']['address'],
+                     'mac_address': mac_addr}]}})
+             ],
+            neutron.update_port.call_args_list
+        )
+        neutron = mock.MagicMock()
+        vrid = 153
+        mac_addr = '00:00:5E:00:02:99'
+        resource_utils.fix_ha_ports_mac(neutron, vip, vrid, use_ipv4=False,
+                                        ports=ports)
+        self.assertEqual(
+            [mock.call(
+                'port_1',
+                {'port': {'allowed_address_pairs': [{
+                    'ip_address': vip['ipv6']['virtual_ip'],
+                    'mac_address': mac_addr}]}}),
+             mock.call(
+                 'port_2',
+                 {'port': {'allowed_address_pairs': [{
+                     'ip_address': vip['ipv6']['virtual_ip'],
+                     'mac_address': mac_addr}]}})
+             ],
+            neutron.update_port.call_args_list
+        )

--- a/heat_infoblox/tests/utils.py
+++ b/heat_infoblox/tests/utils.py
@@ -1,0 +1,28 @@
+# Copyright 2016 Infoblox Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+def create_side_effect(values):
+    def dict_side_effect(key):
+        if key in values:
+            return values[key]
+        else:
+            return None
+    if isinstance(values, dict):
+        return dict_side_effect
+    elif hasattr(values, '__iter__'):
+        return values
+    else:
+        return (values)


### PR DESCRIPTION
Added class Infoblox::Grid::HaPair which get two instances with corrsponding
ports/floating-ips and configure this two instances to be HA pair.
Add HA pair support into resourc  Infoblox::Grid::Member.

HaPair tested with 
[gm-ha.yaml.txt](https://github.com/infobloxopen/heat-infoblox/files/285363/gm-ha.yaml.txt)

GridMember tested with
[member-ha.yaml.txt](https://github.com/infobloxopen/heat-infoblox/files/285558/member-ha.yaml.txt)
