### PR TITLE
Added locks on ns_group update

### DIFF
--- a/heat_infoblox/tests/test_grid_member.py
+++ b/heat_infoblox/tests/test_grid_member.py
@@ -50,7 +50,10 @@ class GridMemberTest(common.HeatTestCase):
         heat_infoblox_path = os.path.abspath(os.path.join(
             os.path.dirname(__file__), os.pardir))
         cfg.CONF.import_opt('plugin_dirs', 'heat.common.config')
+        cfg.CONF.import_opt('lock_path', 'oslo_concurrency.lockutils',
+                            group='oslo_concurrency')
         cfg.CONF.set_override('plugin_dirs', heat_infoblox_path)
+        cfg.CONF.set_override('lock_path', '/tmp/', group='oslo_concurrency')
         super(GridMemberTest, self).setUp()
 
         self.ctx = utils.dummy_context()

--- a/heat_infoblox/tests/test_nameserver_group_member.py
+++ b/heat_infoblox/tests/test_nameserver_group_member.py
@@ -45,7 +45,10 @@ class NameServerGroupMemberTest(common.HeatTestCase):
         heat_infoblox_path = os.path.abspath(os.path.join(
             os.path.dirname(__file__), os.pardir))
         cfg.CONF.import_opt('plugin_dirs', 'heat.common.config')
+        cfg.CONF.import_opt('lock_path', 'oslo_concurrency.lockutils',
+                            group='oslo_concurrency')
         cfg.CONF.set_override('plugin_dirs', heat_infoblox_path)
+        cfg.CONF.set_override('lock_path', '/tmp/', group='oslo_concurrency')
         super(NameServerGroupMemberTest, self).setUp()
 
         self.ctx = utils.dummy_context()


### PR DESCRIPTION
DNS member ns_group updated by sending list of members which cause
invalid group members when some members update same ns_group
simultaneously.
So added locks which prevent group change between 'get_ns_group' and
'update_ns_group'.
