### PR TITLE
Fix GridMember._resolve_attribute

### DIFF
--- a/heat_infoblox/resources/grid_member.py
+++ b/heat_infoblox/resources/grid_member.py
@@ -480,11 +480,12 @@ class GridMember(resource.Resource):
             fail_if_no_member=True,
             return_fields=['host_name', 'vip_setting', 'ipv6_setting',
                            'enable_ha', 'node_info'])
-        token = self._get_member_tokens(member)
         LOG.debug("MEMBER for %s = %s" % (name, member))
         if name == self.USER_DATA:
+            token = self._get_member_tokens(member)
             return self._make_user_data(member, token, 0)
         if name == self.NODE2_USER_DATA:
+            token = self._get_member_tokens(member)
             return self._make_user_data(member, token, 1)
         if name == self.NAME_ATTR:
             return member['host_name']

--- a/heat_infoblox/tests/test_grid_member.py
+++ b/heat_infoblox/tests/test_grid_member.py
@@ -194,6 +194,8 @@ class GridMemberTest(common.HeatTestCase):
             '  certificate: |\n    testing\n',
             ud
         )
+        self.my_member._get_member_tokens.assert_called_once_with(
+            self.ipv4_member)
 
     def test_user_data_lan1_ipv4_dhcp_disabled(self):
         dhcp_status = mock.Mock(return_value={'ipv4': False, 'ipv6': True})
@@ -212,10 +214,12 @@ class GridMemberTest(common.HeatTestCase):
             '  certificate: |\n    testing\n',
             ud
         )
+        self.my_member._get_member_tokens.assert_called_once_with(
+            self.ipv4_member)
 
     def test_user_data_lan1_ipv4_dhcp_enabled(self):
         dhcp_status = mock.Mock(return_value={'ipv4': True, 'ipv6': True})
-        self.set_member(self.ipv4_member)
+        self.set_member_obj(self.ipv4_member)
         self.set_token(['abcdefg', 'hijklmnop'])
         self.my_member._get_dhcp_status_for_port = dhcp_status
         ud = self.my_member._resolve_attribute('user_data')
@@ -227,6 +231,8 @@ class GridMemberTest(common.HeatTestCase):
             '  certificate: |\n    testing\n',
             ud
         )
+        self.my_member._get_member_tokens.assert_called_once_with(
+            self.ipv4_member)
 
     def test_user_data_lan1_ipv6(self):
         self.set_member_obj(self.ipv6_member)
@@ -243,6 +249,8 @@ class GridMemberTest(common.HeatTestCase):
             '  certificate: |\n    testing\n',
             ud
         )
+        self.my_member._get_member_tokens.assert_called_once_with(
+            self.ipv6_member)
 
     def test_user_data_lan1_ipv4_6(self):
         self.set_member_obj(self.ipv4_6_member)
@@ -262,6 +270,8 @@ class GridMemberTest(common.HeatTestCase):
             '  certificate: |\n    testing\n',
             ud
         )
+        self.my_member._get_member_tokens.assert_called_once_with(
+            self.ipv4_6_member)
 
     def test_user_data_ipv4_ha(self):
         self.set_member_obj(self.ipv4_ha_member)
@@ -278,6 +288,8 @@ class GridMemberTest(common.HeatTestCase):
             '  certificate: |\n    testing\n',
             ud
         )
+        self.my_member._get_member_tokens.assert_called_once_with(
+            self.ipv4_ha_member)
 
     def test_user_data2_ipv4_ha(self):
         self.set_member_obj(self.ipv4_ha_member)
@@ -294,6 +306,8 @@ class GridMemberTest(common.HeatTestCase):
             '  certificate: |\n    testing\n',
             ud2
         )
+        self.my_member._get_member_tokens.assert_called_once_with(
+            self.ipv4_ha_member)
 
     def test_temp_licenses_none(self):
         self.set_member(self.base_member)
@@ -362,6 +376,12 @@ class GridMemberTest(common.HeatTestCase):
         self.set_token(['a', 'b'])
         ud = self.my_member._resolve_attribute('user_data')
         self.assertTrue('default_admin_password: infoblox\n' in ud)
+
+    def test_resolve_attribute_name(self):
+        self.set_member_obj(self.ipv4_member)
+        name = self.my_member._resolve_attribute('name')
+        self.assertEqual('host.name', name)
+        self.my_member._get_member_tokens.assert_not_called()
 
     def test_handle_create(self):
         self.set_member(self.base_member)


### PR DESCRIPTION
GridMember function '_resolve_attribute' calls function
'_get_member_tokens' each time. But tokens could be read only for
provisioned members, so this calls caused error.
Function call moved under 'if' so now '_get_member_tokens' called only
if needed.
