### PR TITLE
fix kilo tag in test-requriments

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,7 +7,7 @@ hacking<0.11,>=0.10.0
 bandit>=0.10.1
 coverage>=3.6
 discover
--e git+https://git.openstack.org/openstack/heat.git@stable/kilo#egg=heat
+-e git+https://git.openstack.org/openstack/heat.git@kilo-eol#egg=heat
 mock>=1.2
 mox>=0.5.3
 mox3>=0.7.0


### PR DESCRIPTION
Now heat 'kilo' branch is opbsolete so fix test-requirements from
'stable/kilo' to 'kilo-eol'
