### PR TITLE
update README with HaPair description

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,14 @@ member.
 An example template using this resources is in the doc/templates directory of
 this package.
 
+*Infoblox::Grid::HaPair*
+
+This resource create an HA pair GM, *not* for adding an HA pair to an existing
+grid.
+
+Your should use *Infoblox::Grid::Member* with "ha_pair" set to True to add
+HA pair member into grid.
+
 *Infoblox::Grid::NameServerGroupMember*
 
 This resource represents the membership of a grid member within a name server


### PR DESCRIPTION
Add HaPair description into README.rst
Describe that HaPair is for add HA GM and that Member whith "ha_pair"
set to True should be used to add HA member.
