### PR TITLE
Fix requirements for Liberty

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-pbr!=0.7,<1.0,>=0.6
-Babel>=1.3
+pbr>=1.6
+Babel!=2.3.0,!=2.3.1,!=2.3.2,!=2.3.3,>=1.3 # BSD
 oslo.concurrency>=2.3.0 # Apache-2.0
 oslo.config>=2.3.0 # Apache-2.0
 infoblox-netmri>=0.1.3


### PR DESCRIPTION
The pbr and Babel requirements were left over from Kilo and are
incorrect for Liberty - in fact the pbr one was a non-resolvable
conflict.
